### PR TITLE
Fix search for compojure upgrade

### DIFF
--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -52,7 +52,7 @@
            [:td (format-date created)])]])]))
 
 (defn search [account params]
-  (let [q (params "q")]
-    (if (= (params "format") "json")
+  (let [q (params :q)]
+    (if (= (params :format) "json")
       (json-search q)
       (html-search account q))))


### PR DESCRIPTION
I broke the search page when I did the compojure upgrade to using keyword-params.  This should fix it.
