### PR TITLE
Show non-snapshot on main jar page

### DIFF
--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -132,12 +132,18 @@
 
 (defn find-jar
   ([group jarname]
-     (sql/with-query-results rs
+     (or (sql/with-query-results rs
            [(str "select * from jars where group_name = ? and "
-                 "jar_name = ?"
+                 "jar_name = ? and version not like '%-SNAPSHOT'"
                  " order by created desc limit 1")
             group jarname]
-           (first rs)))
+           (first rs))
+         (sql/with-query-results rs
+           [(str "select * from jars where group_name = ? and "
+                 "jar_name = ? and version like '%-SNAPSHOT'"
+                 " order by created desc limit 1")
+            group jarname]
+           (first rs))))
   ([group jarname version]
      (sql/with-query-results rs
        [(str "select * from jars where group_name = ? and "

--- a/test/clojars/test/integration/jars.clj
+++ b/test/clojars/test/integration/jars.clj
@@ -20,7 +20,7 @@
       (within [:article :h1]
               (has (text? "fake/test")))
       (within [:.lein :pre]
-              (has (text? "[fake/test \"0.0.3-SNAPSHOT\"]")))
+              (has (text? "[fake/test \"0.0.2\"]")))
       (within [:.versions :ul]
               (has (text? "0.0.3-SNAPSHOT0.0.20.0.1")))
       (follow "show all versions (3 total)")
@@ -52,7 +52,7 @@
       (within [:article :h1]
               (has (text? "fake")))
       (within [:.lein :pre]
-              (has (text? "[fake \"0.0.3-SNAPSHOT\"]")))
+              (has (text? "[fake \"0.0.2\"]")))
       (within [:.versions :ul]
               (has (text? "0.0.3-SNAPSHOT0.0.20.0.1")))))
 

--- a/test/clojars/test/unit/db.clj
+++ b/test/clojars/test/unit/db.clj
@@ -140,7 +140,7 @@
     (is (= ["4-SNAPSHOT" "3" "2" "1"]
            (map :version (db/recent-versions name name))))
     (is (= ["4-SNAPSHOT"] (map :version (db/recent-versions name name 1))))
-    (is (= "4-SNAPSHOT" (:version (db/find-jar name name))))
+    (is (= "3" (:version (db/find-jar name name))))
     (is (= "4-SNAPSHOT" (:version (db/find-jar name name "4-SNAPSHOT"))))))
 
 (deftest jars-by-group-returns-all-jars-in-group


### PR DESCRIPTION
This pull request makes it so the version shown on the main jar page is the latest non-snapshot.  It will still show a snapshot if a non-snapshot has not been uploaded.
