### PR TITLE
allow uppercase letters in jar names

### DIFF
--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -208,8 +208,8 @@
                   :version    version})))
 
 (defn add-jar [account jarmap & [check-only]]
-  (when-not (re-matches #"^[a-z0-9-_.]+$" (:name jarmap))
-    (throw (Exception. (str "Jar names must consist solely of lowercase "
+  (when-not (re-matches #"^[a-zA-Z0-9-_.]+$" (:name jarmap))
+    (throw (Exception. (str "Jar names must consist solely of "
                             "letters, numbers, hyphens and underscores."))))
   (transaction
    (if check-only


### PR DESCRIPTION
I have an S3 library called propS3t (a cunning play on "jet" from jetS3t) clojars will not let me deploy the jar because it has capital letters in the filename.

Here I fixed it.
