### PR TITLE
ensure data/ directory exists when running migrations

### DIFF
--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -1,5 +1,6 @@
 (ns clojars.db.migrate
   (:require [clojure.java.jdbc :as sql]
+            [clojure.java.io :as io]
             [clojars.config :refer [config]])
   (:import (java.sql Timestamp)))
 
@@ -22,7 +23,12 @@
                      [(str (:name (meta migration)))
                       (Timestamp. (System/currentTimeMillis))]))
 
+(defn- ensure-db-directory-exists [db]
+  (when-not (.exists (io/file db))
+    (.mkdirs (.getParentFile (io/file db)))))
+
 (defn migrate [& migrations]
+  (ensure-db-directory-exists (:subname (config :db)))
   (sql/with-connection (config :db)
     (try (sql/create-table "migrations"
                            [:name :varchar "NOT NULL"]


### PR DESCRIPTION
Following the dev setup instructions currently results in this:

``` sh
$ lein run -m clojars.db.migrate
All namespaces already :aot compiled.
Exception in thread "main" java.sql.SQLException: path to 'data/dev_db': '/Users/me/code/fork/clojars-web/data' does not exist
        at org.sqlite.Conn.<init>(Conn.java:104)
        at org.sqlite.Conn.<init>(Conn.java:49)
        at org.sqlite.JDBC.connect(JDBC.java:86)
        at java.sql.DriverManager.getConnection(DriverManager.java:582)
        at java.sql.DriverManager.getConnection(DriverManager.java:154)
        at clojure.java.jdbc.internal$get_connection.invoke(internal.clj:168)
        at clojure.java.jdbc.internal$with_connection_STAR_.invoke(internal.clj:186)
        at clojars.db.migrate$migrate.doInvoke(migrate.clj:26)
        at clojure.lang.RestFn.invoke(RestFn.java:421)
        at clojars.db.migrate$_main.invoke(migrate.clj:40)
        at clojure.lang.Var.invoke(Var.java:411)
        at user$eval64.invoke(NO_SOURCE_FILE:1)
        at clojure.lang.Compiler.eval(Compiler.java:6511)
        at clojure.lang.Compiler.eval(Compiler.java:6501)
        at clojure.lang.Compiler.eval(Compiler.java:6477)
        at clojure.core$eval.invoke(core.clj:2797)
        at clojure.main$eval_opt.invoke(main.clj:297)
        at clojure.main$initialize.invoke(main.clj:316)
        at clojure.main$null_opt.invoke(main.clj:349)
        at clojure.main$main.doInvoke(main.clj:427)
        at clojure.lang.RestFn.invoke(RestFn.java:421)
        at clojure.lang.Var.invoke(Var.java:419)
        at clojure.lang.AFn.applyToHelper(AFn.java:163)
        at clojure.lang.Var.applyTo(Var.java:532)
        at clojure.main.main(main.java:37)
```

I updated migrate.clj so it works as intended. Alternatively, we could just add `mkdir data` to the instructions.
