### PR TITLE
add dev dependencies, display after dependencies, close #65

### DIFF
--- a/src/clojars/maven.clj
+++ b/src/clojars/maven.clj
@@ -18,7 +18,8 @@
    :dependencies (vec (map
                         (fn [d] {:group_name (.getGroupId d)
                                  :jar_name (.getArtifactId d)
-                                 :version (.getVersion d)})
+                                 :version (.getVersion d)
+                                 :dev (= "test" (.getScope d))})
                         (.getDependencies model))) })
 
 (defn read-pom

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -16,6 +16,19 @@
    (url-encode (apply format "artifactdetails|%s|%s|%s|jar"
         ((juxt :group_name :jar_name :version) jar)))))
 
+(defn dependency-link [dep]
+  (link-to
+    (if (jar-exists (:group_name dep) (:jar_name dep)) (jar-url dep) (maven-jar-url dep))
+    (str (jar-name dep) " " (:version dep))))
+
+(defn dependency-section [title id dependencies]
+  (if (empty? dependencies) '()
+    (list
+    [:h3 title]
+    [(keyword (str "ul#" id))
+     (for [dep dependencies]
+       [:li (dependency-link dep)])])))
+
 (defn show-jar [account jar recent-versions count]
   (html-doc account (:jar_name jar)
             [:h1 (jar-link jar)]
@@ -43,14 +56,9 @@
              [:p "Pushed by " (user-link (:user jar)) " on " (java.util.Date. (:created jar))]
              (try
                (let [dependencies (:dependencies (jar-to-pom-map jar))]
-               (if-not (empty? dependencies)
-                 (list
-                 [:h3 "dependencies"]
-                 [:ul#dependencies
-                  (for [d dependencies]
-                    [:li (link-to
-                           (if (jar-exists (:group_name d) (:jar_name d)) (jar-url d) (maven-jar-url d))
-                           (str (jar-name d) " " (:version d)))])])))
+                 (concat
+                   (dependency-section "dependencies" "dependencies" (remove :dev dependencies))
+                   (dependency-section "dev dependencies" "dev_dependencies" (filter :dev dependencies))))
                (catch IOException e
                  (.printStackTrace e)
                  [:p.error "Oops. We hit an error opening the metadata POM file for this jar "

--- a/test-resources/fake-0.0.2/fake.pom
+++ b/test-resources/fake-0.0.2/fake.pom
@@ -18,12 +18,16 @@
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
       <version>1.3.0-beta1</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojurer</groupId>
       <artifactId>clojure</artifactId>
       <version>1.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>midje</groupId>
+      <artifactId>midje</artifactId>
+      <version>1.3-alpha4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test-resources/test-maven/test-maven.pom
+++ b/test-resources/test-maven/test-maven.pom
@@ -10,12 +10,16 @@
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
       <version>1.3.0-beta1</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojurer</groupId>
       <artifactId>clojure</artifactId>
       <version>1.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>midje</groupId>
+      <artifactId>midje</artifactId>
+      <version>1.3-alpha4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test/clojars/test/integration/jars.clj
+++ b/test/clojars/test/integration/jars.clj
@@ -97,4 +97,6 @@
   (-> (session web/clojars-app)
       (visit "/fake")
       (within [:ul#dependencies]
-               (has (text? "org.clojure/clojure 1.3.0-beta1org.clojurer/clojure 1.6.0")))))
+               (has (text? "org.clojure/clojure 1.3.0-beta1org.clojurer/clojure 1.6.0")))
+      (within [:ul#dev_dependencies]
+               (has (text? "midje 1.3-alpha4")))))

--- a/test/clojars/test/unit/maven.clj
+++ b/test/clojars/test/unit/maven.clj
@@ -5,8 +5,9 @@
 
 (deftest pom-to-map-returns-corrects-dependencies
   (is (=
-        [{:group_name "org.clojure", :jar_name "clojure", :version "1.3.0-beta1"}
-         {:group_name "org.clojurer", :jar_name "clojure", :version "1.6.0"}]
+        [{:group_name "org.clojure", :jar_name "clojure", :version "1.3.0-beta1" :dev false}
+         {:group_name "org.clojurer", :jar_name "clojure", :version "1.6.0" :dev false}
+         {:group_name "midje", :jar_name "midje", :version "1.3-alpha4", :dev true}]
      (:dependencies (pom-to-map "test-resources/test-maven/test-maven.pom")))))
 
 (deftest directory-for-handles-normal-group-name


### PR DESCRIPTION
Basing dev dependency detection on what I saw in a couple of test poms and confirmed [here](https://github.com/technomancy/leiningen/blob/master/test/leiningen/test/pom.clj#L132)
