### PR TITLE
Patch hiccup to escape strings by default

### DIFF
--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -11,7 +11,7 @@
 (defn start-jetty []
   (when-let [port (:port config)]
     (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" port))
-    (run-jetty clojars-app {:host (:bind config)
+    (run-jetty #'clojars-app {:host (:bind config)
                             :port port
                             :join? false})))
 

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -1,8 +1,9 @@
 (ns clojars.web.common
-  (:require [hiccup.core :refer [html h]]
-            [hiccup.page :refer [html5 include-css include-js]]
+  (:require [hiccup.core :refer [html]]
+            [hiccup.page :refer [include-css include-js]]
             [hiccup.element :refer [link-to unordered-list]]
-            [hiccup.form :refer [form-to]]))
+            [hiccup.form :refer [form-to]]
+            [clojars.web.safe-hiccup :refer [html5 raw]]))
 
 (defn when-ie [& contents]
   (str
@@ -23,7 +24,7 @@
      "Clojars"]
     (map #(include-css (str "/stylesheets/" %))
          ["reset.css" "grid.css" "screen.css"])
-    (when-ie (include-js "/js/html5.js"))]
+    (raw (when-ie (include-js "/js/html5.js")))]
    [:body
     [:div {:class "container_12 header"}
      [:header
@@ -62,7 +63,7 @@
      (unordered-list errors)]))
 
 (defn tag [s]
-  (html [:span {:class "tag"} (h s)]))
+  (raw (html [:span {:class "tag"} s])))
 
 (defn jar-url [jar]
   (if (= (:group_name jar) (:jar_name jar))
@@ -71,8 +72,8 @@
 
 (defn jar-name [jar]
   (if (= (:group_name jar) (:jar_name jar))
-    (h (:jar_name jar))
-    (h (str (:group_name jar) "/" (:jar_name jar)))))
+    (:jar_name jar)
+    (str (:group_name jar) "/" (:jar_name jar))))
 
 (defn jar-link [jar]
   (link-to (jar-url jar) (jar-name jar)))

--- a/src/clojars/web/safe_hiccup.clj
+++ b/src/clojars/web/safe_hiccup.clj
@@ -1,0 +1,33 @@
+(ns clojars.web.safe-hiccup
+  "Hiccup requires explicit (h ..) calls in order to preven XSS.  This
+does some monkey patching to automatically escape strings."
+  (:require [hiccup.core :refer [html]]
+            [hiccup.page :refer [doctype]]
+            [hiccup.util :refer [escape-html to-str ToString]]))
+
+(deftype RawString [s]
+  ToString
+  (to-str [_] s))
+
+(defn raw [s]
+  (RawString. s))
+
+(extend-protocol ToString
+  String
+  (to-str [s] (escape-html (raw s))))
+
+(defmacro html5
+  "Create a HTML5 document with the supplied contents."
+  [options & contents]
+  (if-not (map? options)
+    `(html5 {} ~options ~@contents)
+    (if (options :xml?)
+      `(let [options# ~options]
+         (html {:mode :xml}
+           (raw (xml-declaration (options# :encoding "UTF-8")))
+           (raw (doctype :html5))
+           (xhtml-tag (options# :lang) ~@contents)))
+      `(let [options# ~options]
+         (html {:mode :html}
+           (raw (doctype :html5))
+           [:html {:lang (options# :lang)} ~@contents])))))

--- a/test/clojars/test/unit/web/common.clj
+++ b/test/clojars/test/unit/web/common.clj
@@ -6,9 +6,7 @@
   (is (= "group/artifact" (common/jar-name {:jar_name "artifact"
                                             :group_name "group"})))
   (is (= "artifact" (common/jar-name {:jar_name "artifact"
-                                      :group_name "artifact"})))
-  (is (= "&lt;/alert&gt;/&lt;alert&gt;" (common/jar-name {:jar_name "<alert>"
-                                           :group_name "</alert>"}))))
+                                      :group_name "artifact"}))))
 
 (deftest jar-url-uses-shortest-unique
   (is (= "/group/artifact" (common/jar-url {:jar_name "artifact" :group_name "group"})))


### PR DESCRIPTION
Rather then assume safe by default, change hiccup to use escape by default.

This extends a protocol in hiccup, and might be view as similiar
to monkey patching.  

---

I notice a couple of spots vulnerable to XSS so I'd like to get thoughts on this. I'd prefer this monkey patching type escape by default over exposing an XSS from forgetting to `(h ..)` something.
