### PR TITLE
Fix escaped entities in /projects nav

### DIFF
--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -95,15 +95,17 @@
   (.format (java.text.SimpleDateFormat. "MMM d, yyyy") s))
 
 (defn page-nav [current-page total-pages]
-  (let [page-range 3
+  (let [previous-text (raw "&#8592; Previous")
+        next-text (raw "Next &#8594")
+        page-range 3
         page-url "/projects?page="
         current-page (-> current-page (max 1) (min total-pages))
         main-div [:div {:class "page-nav"}]
         previous-page (if (= current-page 1)
-                        [[:span {:class "previous-page disabled"} "&#8592; Previous"]]
+                        [[:span {:class "previous-page disabled"} previous-text]]
                         [[:a
                           {:href (str page-url (- current-page 1)) :class "previous-page"}
-                          "&#8592; Previous"]])
+                          previous-text]])
         before-current (->> (drop-while
                               #(< % 1)
                               (range (- current-page page-range) current-page))
@@ -114,10 +116,10 @@
                              (range (+ current-page 1) (+ current-page 1 page-range)))
                            (map #(link-to (str page-url %) %)))
         next-page (if (= current-page total-pages)
-                    [[:span {:class "next-page disabled"} "Next &#8594"]]
+                    [[:span {:class "next-page disabled"} next-text]]
                     [[:a
                       {:href (str page-url (+ current-page 1)) :class "next-page"}
-                      "Next &#8594"]])]
+                      next-text]])]
     (vec
       (concat main-div previous-page before-current current after-current next-page))))
 

--- a/test/clojars/test/unit/web/common.clj
+++ b/test/clojars/test/unit/web/common.clj
@@ -1,5 +1,6 @@
 (ns clojars.test.unit.web.common
   (:require [clojars.web.common :as common]
+            [hiccup.util :refer [to-str]]
             [clojure.test :refer :all]))
 
 (deftest jar-name-uses-shortest-unique-and-html-escape
@@ -26,25 +27,28 @@
   (is (= [:a {:href (java.net.URI. "/groups/artifruit")} '("artifruit")]
          (common/group-link "artifruit"))))
 
-(deftest page-nav-renders-disabled-previous-page
-  (is (=
-        [:span {:class "previous-page disabled"} "&#8592; Previous"]
-        (-> (common/page-nav 1 3) (get 2)))))
+(letfn [(cook-content [v]
+          (conj (vec (butlast v)) (to-str (last v))))]
+  
+  (deftest page-nav-renders-disabled-previous-page
+    (is (=
+         [:span {:class "previous-page disabled"} "&#8592; Previous"]
+         (-> (common/page-nav 1 3) (get 2) cook-content))))
 
-(deftest page-nav-renders-active-previous-page
-  (is (=
-        [:a {:href "/projects?page=1" :class "previous-page"} "&#8592; Previous"]
-        (-> (common/page-nav 2 3) (get 2)))))
+  (deftest page-nav-renders-active-previous-page
+    (is (=
+         [:a {:href "/projects?page=1" :class "previous-page"} "&#8592; Previous"]
+         (-> (common/page-nav 2 3) (get 2) cook-content))))
 
-(deftest page-nav-renders-disabled-next-page
-  (is (=
-        [:span {:class "next-page disabled"} "Next &#8594"]
-        (-> (common/page-nav 3 3) (last)))))
+  (deftest page-nav-renders-disabled-next-page
+    (is (=
+         [:span {:class "next-page disabled"} "Next &#8594"]
+         (-> (common/page-nav 3 3) (last) cook-content))))
 
-(deftest page-nav-renders-active-next-page
-  (is (=
-        [:a {:href "/projects?page=3" :class "next-page"} "Next &#8594"]
-        (-> (common/page-nav 2 3) (last)))))
+  (deftest page-nav-renders-active-next-page
+    (is (=
+         [:a {:href "/projects?page=3" :class "next-page"} "Next &#8594"]
+         (-> (common/page-nav 2 3) (last) cook-content)))))
 
 (deftest page-nav-renders-no-before-links
   (is (=


### PR DESCRIPTION
The Next/Previous links on /projects are rendered with the &'s escaped. This uses (raw) to remedy that.
