### PR TITLE
Highlight org.clojars.* forks [issue #77]

### DIFF
--- a/resources/public/stylesheets/screen.css
+++ b/resources/public/stylesheets/screen.css
@@ -269,3 +269,12 @@ p.hint {
 .browse-from input#jump {
   display: none;
 }
+
+.fork a {
+    font-style: italic;
+}
+
+.fork-notice {
+  font-style: italic;
+  font-size: 0.8em;
+}

--- a/src/clojars/web/browse.clj
+++ b/src/clojars/web/browse.clj
@@ -1,6 +1,7 @@
 (ns clojars.web.browse
   (:require [clojars.web.common :refer [html-doc jar-link user-link format-date
-                                        page-nav page-description jar-name]]
+                                        page-nav page-description jar-name
+                                        collection-fork-notice]]
             [clojars.db :refer [browse-projects count-all-projects
                                 count-projects-before]]
             [hiccup.form :refer [label submit-button]]
@@ -17,6 +18,7 @@
        [:input {:type :text :name :from :id :from
                 :placeholder "Enter a few letters..."}]
        [:input {:type :submit :value "Jump" :id :jump}]]]
+     collection-fork-notice
      (page-description page per-page project-count)
      [:ul
       (for [[i jar] (map-indexed vector projects)]

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -79,8 +79,27 @@
     (:jar_name jar)
     (str (:group_name jar) "/" (:jar_name jar))))
 
+(defn jar-fork? [jar]
+  (re-find #"^org.clojars." (or
+                             (:group_name jar)
+                             (:group-id jar)
+                             "")))
+
+(def single-fork-notice
+  [:p.fork-notice
+   "Note: this artifact is a non-canonical fork. See "
+   (link-to "https://github.com/ato/clojars-web/wiki/Groups" "the wiki")
+   " for more details."])
+
+(def collection-fork-notice
+  [:p.fork-notice
+   "Note: artifacts in italics are non-canonical forks. See "
+   (link-to "https://github.com/ato/clojars-web/wiki/Groups" "the wiki")
+   " for more details."])
+
 (defn jar-link [jar]
-  (link-to (jar-url jar) (jar-name jar)))
+  [:span {:class (if (jar-fork? jar) "fork")}
+   (link-to (jar-url jar) (jar-name jar))])
 
 (defn user-link [username]
   (link-to (str "/users/" username) username))

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -1,6 +1,7 @@
 (ns clojars.web.jar
   (:require [clojars.web.common :refer [html-doc jar-link group-link
                                         tag jar-url jar-name user-link
+                                        jar-fork? single-fork-notice
                                         simple-date]]
             [hiccup.element :refer [link-to]]
             [hiccup.form :refer [submit-button]]
@@ -37,6 +38,10 @@
 (defn safe-link-to [url text]
   (try (link-to url text)
     (catch Exception e text)))
+
+(defn fork-notice [jar]
+  (when (jar-fork? jar)
+    single-fork-notice))
 
 (defn promotion-details [account jar]
   (if (authorized? account (:group_name jar))
@@ -82,6 +87,7 @@
                    [:span {:title (str (java.util.Date. (:created jar)))} (simple-date (:created jar))]
                    (if-let [url (commit-url pom)]
                      [:span.commit-url " with " (link-to url "this commit")])]
+                 (fork-notice jar)
                  (promotion-details account jar)
                  (dependency-section "dependencies" "dependencies"
                                      (remove #(not= (:scope %) "compile") (:dependencies pom)))
@@ -99,7 +105,7 @@
 
 (defn show-versions [account jar versions]
   (html-doc account (str "all versions of "(jar-name jar))
-            [:h1 "all versions of "(jar-name jar)]
+            [:h1 "all versions of "(jar-link jar)]
             [:div {:class "versions"}
              [:ul
               (for [v versions]

--- a/test/clojars/test/integration/web.clj
+++ b/test/clojars/test/integration/web.clj
@@ -55,5 +55,5 @@
       (fill-in "starting from" "tester/tester123")
       (press "Jump")
       (follow-redirect)
-      (within [[:li.browse-results (enlive/nth-of-type 3)] [:a (enlive/nth-of-type 2)]]
+      (within [[:li.browse-results (enlive/nth-of-type 3)] [:span (enlive/nth-of-type 1)] :a]
               (has (text? "tester/tester123a")))))


### PR DESCRIPTION
This highlights org.clojars.\* forks with italics anywhere jar-link is used, 
which includes:
- the search results page
- the dashboard
- the projects browse page
- the header on the jar view page
- the header on the versions page (another change in this commit)
- probably other places I'm not aware of

It also adds a notice to the view page for a jar if it is a fork, and a
notice to the top of the search results if any forks are in the result set.
The notice links to the Groups wiki page for more information.
