### PR TITLE
Renaming external references from "jars" to "projects"

### DIFF
--- a/src/clojars/event.clj
+++ b/src/clojars/event.clj
@@ -19,7 +19,7 @@
   ;; ramifications on usability, security and compatiblity with filesystems,
   ;; OSes, URLs and tools.
   (validate-regex artifact-id #"^[a-z0-9_.-]+$"
-                  (str "Jar names must consist solely of lowercase "
+                  (str "Project names must consist solely of lowercase "
                        "letters, numbers, hyphens and underscores."))
   (validate-regex group-id #"^[a-z0-9_.-]+$"
                   (str "Group names must consist solely of lowercase "

--- a/src/clojars/web/common.clj
+++ b/src/clojars/web/common.clj
@@ -29,7 +29,7 @@
      [:header
       [:hgroup {:class :grid_4}
        [:h1 (link-to "/" "Clojars")]
-       [:h2 "Simple Clojure jar repository"]]
+       [:h2 "Simple Clojure project repository"]]
       [:nav
        (if account
          (unordered-list
@@ -41,7 +41,7 @@
            (link-to "/register" "register")]))
        (form-to [:get "/search"]
                 [:input {:name "q" :id "search" :class :search
-                         :placeholder "Search jars..."}])]]
+                         :placeholder "Search projects..."}])]]
      [:div {:class :clear}]]
     [:div {:class "container_12 article"}
      [:article.clearfix

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -27,20 +27,20 @@
        (tag "  <url>") "http://clojars.org/repo" (tag "</url>\n")
        (tag "</repository>")]]]
 
-    [:p "To " [:strong "get started"] " pushing your own jars "
+    [:p "To " [:strong "get started"] " pushing your own projects "
      (link-to "/register" "create an account")
      " and then check out the "
      (link-to "http://wiki.github.com/ato/clojars-web/tutorial"
               "tutorial") ". Alternatively, "
      (link-to "/projects" "browse") " the repository."]
-    [:h2 "Recently pushed jars"]
+    [:h2 "Recently pushed projects"]
     (unordered-list (map jar-link (recent-jars)))))
 
 (defn dashboard [account]
   (html-doc account "Dashboard"
     [:h1 (str "Dashboard (" account ")")]
-    [:h2 "Your jars"]
+    [:h2 "Your projects"]
     (unordered-list (map jar-link (jars-by-username account)))
-    (link-to "http://wiki.github.com/ato/clojars-web/pushing" "add new jar")
+    (link-to "http://wiki.github.com/ato/clojars-web/pushing" "add new project")
     [:h2 "Your groups"]
     (unordered-list (map group-link (find-groupnames account)))))

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -9,7 +9,7 @@
 (defn show-group [account groupname membernames & errors]
   (html-doc account (str groupname " group")
     [:h1 (str groupname " group")]
-    [:h2 "Jars"]
+    [:h2 "Projects"]
     (unordered-list (map jar-link (jars-by-groupname groupname)))
     [:h2 "Members"]
     (unordered-list (map user-link membernames))

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -109,7 +109,7 @@
                  (dependency-section "dependencies" "dependencies"
                                      (remove #(not= (:scope %) "compile") (:dependencies pom)))
                  (when-not pom
-                   [:p.error "Oops. We hit an error opening the metadata POM file for this jar "
+                   [:p.error "Oops. We hit an error opening the metadata POM file for this project "
                     "so some details are not available."])))
               [:h3 "recent versions"]
               [:ul#versions

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -110,7 +110,7 @@
 (defn show-user [account user]
   (html-doc account (user :user)
     [:h1 (user :user)]
-    [:h2 "Jars"]
+    [:h2 "Projects"]
     (unordered-list (map jar-link (jars-by-username (user :user))))
     [:h2 "Groups"]
     (unordered-list (map group-link (find-groupnames (user :user))))))


### PR DESCRIPTION
Attempting to resolve https://github.com/ato/clojars-web/issues/84.

This doesn't change any of the code, merely the external references to jars. Updating the code is probably better left to https://github.com/ato/clojars-web/issues/81.
