### PR TITLE
Add X-Frame-Options DENY to group/profile/forgot-password forms.

### DIFF
--- a/src/clojars/routes/group.clj
+++ b/src/clojars/routes/group.clj
@@ -7,8 +7,10 @@
 (defroutes routes
   (GET ["/groups/:groupname", :groupname #"[^/]+"] [groupname]
        (if-let [membernames (db/group-membernames groupname)]
-         (auth/try-account
-          (view/show-group account groupname membernames))))
+         {:body (auth/try-account
+                 (view/show-group account groupname membernames))
+          :headers {"X-Frame-Options" "DENY"}
+          :status 200}))
   (POST ["/groups/:groupname", :groupname #"[^/]+"] [groupname username]
         (if-let [membernames (db/group-membernames groupname)]
           (auth/try-account

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -11,8 +11,10 @@
 
 (defroutes routes
   (GET "/profile" {:keys [flash]}
-       (auth/with-account
-         (view/profile-form account flash)))
+       {:body (auth/with-account
+                (view/profile-form account flash))
+        :headers {"X-Frame-Options" "DENY"}
+        :status 200})
   (POST "/profile" {:keys [params]}
         (auth/with-account
           (view/update-profile account params)))
@@ -21,7 +23,9 @@
        (view/register-form))
 
   (GET "/forgot-password" _
-       (view/forgot-password-form))
+       {:body (view/forgot-password-form)
+        :headers {"X-Frame-Options" "DENY"}
+        :status 200})
   (POST "/forgot-password" {:keys [params]}
         (view/forgot-password params))
 


### PR DESCRIPTION
This covers the only POST actions that currently exist in the
codebase, but perhaps a whitelist approach would be better in order to
prevent future additions from being missed?
