### PR TITLE
Throttle failed login attempts.

### DIFF
--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -71,7 +71,7 @@
                  (when (not (empty? password))
                    (swap! attempts dissoc user)
                    {:username user :password password})
-                 (swap! attempts bad-attempt id))))))
+                 (do (swap! attempts bad-attempt id) nil))))))
 
 (defroutes clojars-app
   (context "/repo" _


### PR DESCRIPTION
Each failed attempt gets recorded and penalized by a delay of the
square of the previous failed attempts in milliseconds. This will be
unnoticeable for legitimate failures but quickly adds up for guessing
attackers; a hundred failed attempts adds a ten-second delay.

A successful login clears the failed attempts.
