### PR TITLE
suggest no-cache of latest image svgs

### DIFF
--- a/src/clojars/routes/artifact.clj
+++ b/src/clojars/routes/artifact.clj
@@ -57,11 +57,13 @@
   (GET ["/:artifact-id/latest-version.svg" :artifact-id #"[^/]+"]
        [artifact-id]
        (-> (response/response (view/make-latest-version-svg artifact-id artifact-id))
+           (response/header "Cache-Control" "no-cache")
            (response/content-type "image/svg+xml")))
   (GET ["/:group-id/:artifact-id/latest-version.svg"
         :group-id #"[^/]+" :artifact-id #"[^/]+"]
        [group-id artifact-id]
        (-> (response/response (view/make-latest-version-svg group-id artifact-id))
+           (response/header "Cache-Control" "no-cache")
            (response/content-type "image/svg+xml")))
 
   (POST ["/:group-id/:artifact-id/promote/:version"


### PR DESCRIPTION
To stop github from caching the badges to an old version.
