### PR TITLE
Improve search result quality.

### DIFF
--- a/test/clojars/test/test_helper.clj
+++ b/test/clojars/test/test_helper.clj
@@ -5,6 +5,7 @@
             [clojars.config :refer [config]]
             [korma.db :as kdb]
             [clucy.core :as clucy]
+            [clojars.search :as search]
             [clojure.test :as test]
             [clojure.java.shell :as sh]
             [clojure.java.io :as io]
@@ -63,8 +64,9 @@
     (if (empty? v)
       (do (clucy/add index {:dummy true})
           (clucy/search-and-delete index "dummy:true"))
-      (doseq [a v]
-        (clucy/add index a)))))
+      (binding [clucy/*analyzer* search/analyzer]
+        (doseq [a v]
+          (clucy/add index a))))))
 
 (defn default-fixture [f]
   (using-test-config

--- a/test/clojars/test/unit/search.clj
+++ b/test/clojars/test/unit/search.clj
@@ -6,22 +6,23 @@
 (use-fixtures :each help/default-fixture)
 
 (deftest weight-by-downloads
-  (help/make-download-count! {["asd" "alfred"] {"0.0.1" 1}
-                              ["b" "alfred"] {"0.1.0" 5}
-                              ["c" "c"] {"0.1.0" 5}})
-  (help/make-index! [{:artifact-id "alfred"
-                      :group-id "asd"}
-                     {:artifact-id "alfred"
-                      :group-id "b"}
+  (help/make-download-count! {["lein-ring" "lein-ring"] {"0.0.1" 10000}
+                              ["lein-modules" "lein-modules"] {"0.1.0" 200}
+                              ["c" "c"] {"0.1.0" 100000}})
+  (help/make-index! [{:artifact-id "lein-ring"
+                      :group-id "lein-ring"}
+                     {:artifact-id "lein-modules"
+                      :group-id "lein-modules"}
                      {:artifact-id "c"
                       :group-id "c"}])
-  (is (= (search/search "alfred")
-         [{:artifact-id "alfred"
-           :group-id "b"}
-          {:artifact-id "alfred"
-           :group-id "asd"}]))
-  (is (= (search/search "asd alfred")
-         [{:artifact-id "alfred"
-           :group-id "asd"}
-          {:artifact-id "alfred"
-           :group-id "b"}])))
+  (is (= (search/search "lein-modules")
+         [{:group-id "lein-modules", :artifact-id "lein-modules"}
+          {:group-id "lein-ring", :artifact-id "lein-ring"}]))
+  (is (= (search/search "lein-ring")
+         [{:group-id "lein-ring", :artifact-id "lein-ring"}
+          {:group-id "lein-modules", :artifact-id "lein-modules"}]))
+  (is (= (search/search "lein")
+         [{:group-id "lein-ring", :artifact-id "lein-ring"}
+          {:group-id "lein-modules", :artifact-id "lein-modules"}]))
+  (is (= (search/search "ring")
+         [{:group-id "lein-ring", :artifact-id "lein-ring"}])))


### PR DESCRIPTION
This should fix issues #197 and #194.

We no longer give so much weight to the number of downloads. Previously, the number of downloads could change an item's search score by a factor of about 500,000x (for `ring-core`, with approx. 500K downloads).  This meant that a search that had any terms in common with popular items almost always returned those items at the top, even if there was an item that had a perfect text match.

With this change, `ring-core`'s downloads would only give it a multiplier of about 2.43x.

Here's a look at the the first 5 items returned by various searches, comparing the old code to the new code.
### Search for 'lein-garden'

Old:

| Name | Description |
| --- | --- |
| lein-ring 0.8.10 | Leiningen Ring plugin |
| lein-cljsbuild 1.0.3 | ClojureScript Autobuilder Plugin |
| lein-midje 3.1.3 | Run Midje and clojure.test tests |
| lein-newnew 0.3.7 | A Leiningen plugin for generating new projects based on templates. |
| lein-cljsbuild/cljs-compat 1.0.0-SNAPSHOT | Matrix of cljsbuild/ClojureScript compatibility |

New:

| Name | Description |
| --- | --- |
| lein-garden 0.1.8 | A Leiningen plugin for automatically compiling Garden stylesheets |
| org.clojars.nbeloglazov/lein-garden 0.1.0-SNAPSHOT | Lein plugin for compiling garden files to css. |
| lein-describe 0.2.0 | A Leiningen plugin for displaying detailed project information. |
| garden-watch 0.1.7 | Garden source to CSS watcher and converter |
| malcolmsparks/garden 0.1.0-beta | A library for generating CSS in Clojure. |

`lein-describe` shows up because it incorrectly lists its repository
as https://github.com/noprompt/lein-garden
### Search for 'lein-modules'

Old:

| Name | Description |
| --- | --- |
| lein-ring 0.8.10 | Leiningen Ring plugin |
| lein-cljsbuild 1.0.3 | ClojureScript Autobuilder Plugin |
| lein-midje 3.1.3 | Run Midje and clojure.test tests |
| org.apache.hadoop/hadoop-core 0.20.2-dev | Hadoop is the distributed computing framework of Apache; hadoop-core contains the filesystem, job tracker and map/reduce modules |
| lein-newnew 0.3.7 | A Leiningen plugin for generating new projects based on templates. |

New:

| Name | Description |
| --- | --- |
| lein-modules 0.3.1 | Similar to Maven multi-module projects, but less sucky |
| modules |  |
| modules |  |
| modules |  |
| modules |  |

Those bogus `modules` items are due to issue #132.
### Search for 'lein-ring'

Old:

| Name | Description |
| --- | --- |
| ring/ring-core 1.3.0-beta2 | Ring core libraries. |
| ring/ring-servlet 1.3.0-beta2 | Ring servlet utilities. |
| ring/ring-jetty-adapter 1.3.0-beta2 | Ring Jetty adapter. |
| ring/ring-devel 1.3.0-beta2 | Ring development and debugging libraries. |
| lein-ring 0.8.10 | Leiningen Ring plugin |

New:

| Name | Description |
| --- | --- |
| lein-ring 0.8.10 89902 | Leiningen Ring plugin |
| com.andrewmcveigh/lein-ring 0.8.3-SNAPSHOT 59 | Leiningen Ring plugin |
| org.clojars.strongh/lein-ring 0.8.7 16 | Leiningen Ring plugin |
| org.clojars.abbot/lein-ring 0.8.7 5 | Leiningen Ring plugin |
| jarohen/lein-ring 0.8.4-SNAPSHOT 3 | Leiningen Ring plugin |
### Search for 'compojure'

Just to show that we still do well on popular items.

Old:

| Name | Description |
| --- | --- |
| compojure 1.1.8 | A concise routing library for Ring |
| compojure/lein-template 0.3.4 | Compojure project template for Leiningen |
| compojure-app/lein-template 0.4.2 | Compojure project template for Leiningen |
| shoreleave/shoreleave-remote-ring 0.3.0 | A smarter client-side with ClojureScript : Ring- (and Compojure-) server-side Remotes support |
| sandbar 0.3.3 | Clojure web application libraries built on top of Ring and Compojure. |

New:

| Name | Description |
| --- | --- |
| compojure 1.1.8 | A concise routing library for Ring |
| org.clojars.ctdean/compojure 0.3.1 |  |
| org.clojars.tomo/compojure 0.3.1 |  |
| metosin/compojure-api 0.11.3 | Compojure Api |
| compojure-throttle 0.1.5 | Throttling middleware for compojure |
