### PR TITLE
Return an empty map when all.edn stats not found

### DIFF
--- a/src/clojars/stats.clj
+++ b/src/clojars/stats.clj
@@ -1,10 +1,14 @@
 (ns clojars.stats
-  (:require [clojars.config :as config]))
+  (:require [clojars.config :as config]
+            [clojure.java.io :as io]))
 
 (defn all []
-  (read (java.io.PushbackReader. (java.io.FileReader.
-                                  (str (config/config :stats-dir)
-                                       "/all.edn")))))
+  (let [path (str (config/config :stats-dir) "/all.edn")]
+    (if (.exists (io/as-file path))
+      (read (java.io.PushbackReader. (java.io.FileReader.
+                                      (str (config/config :stats-dir)
+                                           "/all.edn"))))
+      {})))
 
 (defn download-count [dls group-id artifact-id & [version]]
   (let [ds (dls [group-id artifact-id])]


### PR DESCRIPTION
Hi,

This PR checks to see if the all.edn stats exist, if not it returns a default empty map.

Currently if you clone the project, lein migrate and load the test data you are presented with a stack trace upon loading the site as it expects the file to exist. This fixes this although obviously download counts etc will be 0.

Any thoughts or questions let me know.
Thanks,
Ben
