### PR TITLE
Clean up the embeddable latest version SVG colors

### DIFF
--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -195,12 +195,12 @@
                                       :version (:version v)))
                            (:version v))])]]]))
 
-(let [border-color "#9c92d9"
-      bg-color "#380036"
-      artifact-color  "#ffffff"
-      version-color "#27d3f1"
+(let [border-color "#e2e4e3"
+      bg-color "#fff"
+      artifact-color  "#4098cf"
+      version-color "#87cf29"
       bracket-color "#ffb338"
-      powered-by-color "#ffffff"
+      ampersand-color "#888"
       clojars-color "#ffb338"]
   (defn svg-template [jar-id version]
     (let [width-px (+ 138 (* (+ (count jar-id) (count version)) 6))]
@@ -235,7 +235,7 @@
                :y 14,
                :font-family "Verdana",
                :font-size 8,
-               :fill powered-by-color}
+               :fill ampersand-color}
         [:tspan "@"]
         [:tspan {:fill clojars-color} "clojars.org"]]])))
 


### PR DESCRIPTION
I tried an experiment with the artifact version colors, but in retrospect they were a mistake. This is cleaner, and IMO quite a bit better.
![screen shot 2014-07-07 at 7 52 14 pm](https://cloud.githubusercontent.com/assets/10421/3503840/23306224-063a-11e4-82ab-b5c73c2be0d6.png)
