### PR TITLE
Use clj-pgp to verify signature of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Options may be read from a file using the `-f` switch, setting the
 Clojure map:
 
     {:db {:classname "org.sqlite.JDBC"
-	  :subprotocol "sqlite"
-	  :subname "data/dev_db"}
+          :subprotocol "sqlite"
+          :subname "data/dev_db"}
      :key-file "data/dev_authorized_keys"
      :repo "data/dev_repo"
      :bcrypt-work-factor 12
      :mail {:hostname "localhost"
-	    :from "noreply@clojars.org"
-	    :ssl false}}
+            :from "noreply@clojars.org"
+            :ssl false}}
 
 The classpath option can be used with Leiningen 2 profiles.  When
 running out of a source checkout using `lein run` the configuration
@@ -106,6 +106,9 @@ you can use like this:
     mkdir -p data
     rm -f data/dev_db
     gunzip -c clojars-test-data.sql.gz | sqlite3 data/dev_db
+
+After this you should still run `lein migrate` to update the db schema to
+the latest version.
 
 If you want all the actual jar files as well you can grab them via
 [rsync](http://github.com/ato/clojars-web/wiki/Data).

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject clojars-web "0.15.11-SNAPSHOT"
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [org.apache.maven/maven-model "3.0.4"
                   :exclusions
@@ -27,7 +27,8 @@
                  [valip "0.2.0"]
                  [clucy "0.3.0"]
                  [org.clojure/tools.nrepl "0.2.3"]
-                 [org.bouncycastle/bcpg-jdk15on "1.47"]]
+                 [org.bouncycastle/bcpg-jdk15on "1.47"]
+                 [mvxcvi/clj-pgp "0.8.0"]]
   :profiles {:dev {:dependencies [[kerodon "0.0.7"]
                                   [nailgun-shim "0.0.1"]]
                    :resource-paths ["local-resources"]}}


### PR DESCRIPTION
Clj-pgp requires Clojure 1.6.0 so I updated the dependency. Tests pass still so hopefully this didn't cause regressions.

This fixes at least the problem I've been having: #246 
Probably this will also fix bugs: #244, #271, #204, and #134

I tested this locally by creating two users. I first pushed a artifact with user1 thus creating a group. I then added user2 to the group and pushed another version of the artifact with credentials of user2 (and different pgp key). With this fix the user2 is able to promote the artifact.
I checked that if I removed pubkey from user2's profile, the promote is not available etc.