### PR TITLE
use release version of korma

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [ring/ring-jetty-adapter "1.1.1"]
                  [hiccup "1.0.3"]
                  [cheshire "3.0.0"]
-                 [korma "0.3.0-beta10"]
+                 [korma "0.3.0"]
                  [org.clojars.ato/nailgun "0.7.1"]
                  [org.xerial/sqlite-jdbc "3.7.2"]
                  [org.apache.commons/commons-email "1.2"]


### PR DESCRIPTION
latest release is actually 0.4.0, and a lot of other dependencies are
out of date, but moving from a beta version to a corresponding release
version seemed higher priority/less likely to break anything