### PR TITLE
Enable `latest-version.json' endpoint

### DIFF
--- a/src/clojars/routes/artifact.clj
+++ b/src/clojars/routes/artifact.clj
@@ -31,6 +31,19 @@
                     (db/recent-versions group-id artifact-id 5)
                     (db/count-versions group-id artifact-id)))))
 
+(defn response-based-on-format
+  "render appropriate response based on the file type suffix provided:
+  JSON or SVG"
+  [file-format artifact-id & [group-id]]
+  (let [group-id (or group-id artifact-id)]
+  (cond
+    (= file-format "json") (-> (response/response (view/make-latest-version-json group-id artifact-id))
+                               (response/header "Cache-Control" "no-cache")
+                               (response/content-type "application/json; charset=UTF-8"))
+    (= file-format "svg") (-> (response/response (view/make-latest-version-svg group-id artifact-id))
+                              (response/header "Cache-Control" "no-cache")
+                              (response/content-type "image/svg+xml")))))
+
 (defroutes routes
   (GET ["/:artifact-id", :artifact-id #"[^/]+"] [artifact-id]
        (show artifact-id artifact-id))
@@ -58,20 +71,14 @@
         :artifact-id #"[^/]+"
         :file-format #"(svg|json)$"]
        [artifact-id file-format]
-       (cond
-         (= file-format "json") (-> (response/response (view/make-latest-version-json artifact-id artifact-id))
-                                    (response/header "Cache-Control" "no-cache")
-                                    (response/content-type "application/json; charset=UTF-8"))
-         (= file-format "svg") (-> (response/response (view/make-latest-version-svg artifact-id artifact-id))
-                                    (response/header "Cache-Control" "no-cache")
-                                    (response/content-type "image/svg+xml"))))
+       (response-based-on-format file-format artifact-id))
 
-  (GET ["/:group-id/:artifact-id/latest-version.svg"
-        :group-id #"[^/]+" :artifact-id #"[^/]+"]
-       [group-id artifact-id]
-       (-> (response/response (view/make-latest-version-svg group-id artifact-id))
-           (response/header "Cache-Control" "no-cache")
-           (response/content-type "image/svg+xml")))
+  (GET ["/:group-id/:artifact-id/latest-version.:file-format"
+        :group-id #"[^/]+"
+        :artifact-id #"[^/]+"
+        :file-format #"(svg|json)$"]
+       [group-id artifact-id file-format]
+       (response-based-on-format file-format artifact-id group-id))
 
   (POST ["/:group-id/:artifact-id/promote/:version"
          :group-id #"[^/]+" :artifact-id #"[^/]+" :version #"[^/]+"]

--- a/src/clojars/routes/artifact.clj
+++ b/src/clojars/routes/artifact.clj
@@ -54,11 +54,18 @@
        [group-id artifact-id version]
        (show-version group-id artifact-id version))
 
-  (GET ["/:artifact-id/latest-version.svg" :artifact-id #"[^/]+"]
-       [artifact-id]
-       (-> (response/response (view/make-latest-version-svg artifact-id artifact-id))
-           (response/header "Cache-Control" "no-cache")
-           (response/content-type "image/svg+xml")))
+  (GET ["/:artifact-id/latest-version.:file-format"
+        :artifact-id #"[^/]+"
+        :file-format #"(svg|json)$"]
+       [artifact-id file-format]
+       (cond
+         (= file-format "json") (-> (response/response (view/make-latest-version-json artifact-id artifact-id))
+                                    (response/header "Cache-Control" "no-cache")
+                                    (response/content-type "application/json; charset=UTF-8"))
+         (= file-format "svg") (-> (response/response (view/make-latest-version-svg artifact-id artifact-id))
+                                    (response/header "Cache-Control" "no-cache")
+                                    (response/content-type "image/svg+xml"))))
+
   (GET ["/:group-id/:artifact-id/latest-version.svg"
         :group-id #"[^/]+" :artifact-id #"[^/]+"]
        [group-id artifact-id]

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -246,3 +246,8 @@
      "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"
  \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">"
      (svg-template (jar-name jar) (:version jar)))))
+
+(defn make-latest-version-json [group-id artifact-id]
+  "Return the latest version of a JAR as JSON"
+  (let [jar (find-jar group-id artifact-id)]
+    (str "{\"version\":\"" (:version jar) "\"}")))


### PR DESCRIPTION
My motivation for creating this is to be able to retreive the latest
version of a given clojar as JSON in the format of:

  {"version": "0.1.3"}

So that we can have pretty badges like this:

[![Example clojar badge](https://img.shields.io/badge/clojars%20version-0.1.3-brightgreen.svg)](https://clojars.org/pdfboxing)

as provided by http://shields.io/.

I'm well aware that **/some-clojar/latest-version.svg** endpoint exists, and it renders the badge already. But isn't in the same format as all the badges provided by GitHub et la. 

With this PR you get the uniform look of the badges handled for you by this third party service, should the users want to. All you've got to provide them with is JSON. Which, if we're going to split hairs, would consume less bandwidth than the XML currently generated.

Also, somebody already created a PR on the shields repo: https://github.com/badges/shields/pull/388 where they would use the **/search** end point. Which isn't going to be very efficient, since it won't try to look up a particular clojar's version, but it'll search through all the clojars first, only to return the latest version of one clojar. Which isn't optimal.