### PR TITLE
Api endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                   :exclusions [org.clojure/core.incubator]]
                  [ring/ring-jetty-adapter "1.1.1"]
                  [hiccup "1.0.3"]
-                 [cheshire "3.0.0"]
+                 [cheshire "5.4.0"]
                  [korma "0.3.0-beta10"]
                  [org.clojars.ato/nailgun "0.7.1"]
                  [org.xerial/sqlite-jdbc "3.7.2"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,8 @@
                  [org.bouncycastle/bcpg-jdk15on "1.47"]
                  [mvxcvi/clj-pgp "0.8.0"]]
   :profiles {:dev {:dependencies [[kerodon "0.0.7"]
-                                  [nailgun-shim "0.0.1"]]
+                                  [nailgun-shim "0.0.1"]
+                                  [clj-http-lite "0.2.1"]]
                    :resource-paths ["local-resources"]}}
   :plugins [[lein-ring "0.8.5"]]
   :aliases {"migrate" ["run" "-m" "clojars.db.migrate"]}

--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,9 @@
                   :exclusions
                   [org.apache.httpcomponents/httpcore]]
                  [s3-wagon-private "1.0.0"]
-                 [compojure "1.1.5"
-                  :exclusions [org.clojure/core.incubator]]
+                 [compojure "1.3.3"]
                  [ring/ring-jetty-adapter "1.1.1"]
+                 [ring-middleware-format "0.5.0"]
                  [hiccup "1.0.3"]
                  [cheshire "5.4.0"]
                  [korma "0.3.0-beta10"]
@@ -20,8 +20,9 @@
                  [commons-codec "1.6"]
                  [net.cgrand/regex "1.0.1"
                   :exclusions [org.clojure/clojure]]
-                 [clj-time "0.3.8"]
-                 [com.cemerick/friend "0.1.4"]
+                 [clj-time "0.9.0"]
+                 [com.cemerick/friend "0.2.1"
+                  :exclusions [org.clojure/core.cache]]
                  [clj-stacktrace "0.2.6"]
                  [ring-anti-forgery "0.2.1"]
                  [valip "0.2.0"]

--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -28,5 +28,6 @@
   (admin/init)
   (start-nailgun))
 
-;; (def server (run-jetty #'clojars-app {:port 8080 :join? false}))
-;; (.stop server)
+(comment
+  (def server (run-jetty #'clojars-app {:port 8080 :join? false}))
+  (.stop server))

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -1,5 +1,6 @@
 (ns clojars.routes.api
-  (:require [compojure.core :refer [GET ANY defroutes context]]
+  (:require [clojure.set :refer [rename-keys]]
+            [compojure.core :refer [GET ANY defroutes context]]
             [compojure.route :refer [not-found]]
             [clojars.db :as db]
             [clojars.web.common :as common]
@@ -19,13 +20,42 @@
                                                  versions)))
             json/generate-string)))
 
+(defn jars-by-groupname [groupname]
+    (exec-raw [(str
+              "select j.*, j2.version as latest_release "
+              "from jars j "
+              ;; Find the latest version
+              "join "
+              "(select jar_name, max(created) as created "
+              "from jars "
+              "group by group_name, jar_name) l "
+              "on j.jar_name = l.jar_name "
+              "and j.created = l.created "
+              ;; Find the latest release
+              "join "
+              "(select jar_name, max(created) as created "
+              "from jars "
+              "where version not like '%-SNAPSHOT' "
+              "group by group_name, jar_name) r "
+              "on j.jar_name = r.jar_name "
+              ;; Join with latest release
+              "join "
+              "(select jar_name, created, version from jars) as j2 "
+              "on j2.jar_name = j.jar_name "
+              "and j2.created = r.created "
+              "where j.group_name = ? "
+              "order by j.group_name asc, j.jar_name asc")
+             [groupname]]
+              :results))
+
 (defroutes routes
   (context "/api" []
     (GET ["/groups/:group-id", :group-id #"[^/]+"] [group-id]
       (let [stats (stats/all)]
-        (-> (db/jars-by-groupname group-id)
+        (-> (jars-by-groupname group-id)
             (->> (map (fn [jar]
                         (-> jar
+                            (rename-keys {:version :latest_version})
                             (dissoc :id :created :promoted_at)
                             (assoc :downloads (stats/download-count stats group-id (:jar_name jar)))))))
             json/generate-string)))

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -18,10 +18,11 @@
       [group-id artifact-id]
       (let [stats (stats/all)]
         (some-> (db/find-jar group-id artifact-id)
-                (assoc :recent-versions (db/recent-versions group-id artifact-id)
-                       :total-downloads (stats/download-count stats group-id artifact-id))
-                (update-in [:recent-versions] (fn [versions]
-                                                (map #(assoc % :downloads (stats/download-count stats group-id artifact-id (:version %)))
+                (assoc :recent_versions (db/recent-versions group-id artifact-id)
+                       :downloads (stats/download-count stats group-id artifact-id))
+                (update-in [:recent_versions] (fn [versions]
+                                                (map (fn [version]
+                                                       (assoc version :downloads (stats/download-count stats group-id artifact-id (:version version))))
                                                      versions)))
                 (json/generate-string))))
     (ANY "*" _

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -1,0 +1,28 @@
+(ns clojars.routes.api
+  (:require [compojure.core :refer [GET ANY defroutes context]]
+            [compojure.route :refer [not-found]]
+            [clojars.db :as db]
+            [clojars.web.common :as common]
+            [clojars.stats :as stats]
+            [cheshire.core :as json]))
+
+(defroutes routes
+  (context "/api" []
+    (GET ["/:group-id", :group-id #"[^/]+"] [group-id]
+      (let [stats (stats/all)]
+        (-> (db/jars-by-groupname group-id)
+            (->> (map (fn [jar]
+                        (assoc jar :downloads (stats/download-count stats group-id (:jar_name jar))))))
+            (json/generate-string))))
+    (GET ["/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"]
+      [group-id artifact-id]
+      (let [stats (stats/all)]
+        (some-> (db/find-jar group-id artifact-id)
+                (assoc :recent-versions (db/recent-versions group-id artifact-id)
+                       :total-downloads (stats/download-count stats group-id artifact-id))
+                (update-in [:recent-versions] (fn [versions]
+                                                (map #(assoc % :downloads (stats/download-count stats group-id artifact-id (:version %)))
+                                                     versions)))
+                (json/generate-string))))
+    (ANY "*" _
+      (not-found nil))))

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -4,26 +4,37 @@
             [clojars.db :as db]
             [clojars.web.common :as common]
             [clojars.stats :as stats]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [korma.core :refer [exec-raw]]))
+
+(defn get-artifact [group-id artifact-id]
+  (let [stats (stats/all)]
+    (some-> (db/find-jar group-id artifact-id)
+            (dissoc :id :created :promoted_at)
+            (assoc :recent_versions (db/recent-versions group-id artifact-id)
+                   :downloads (stats/download-count stats group-id artifact-id))
+            (update-in [:recent_versions] (fn [versions]
+                                            (map (fn [version]
+                                                   (assoc version :downloads (stats/download-count stats group-id artifact-id (:version version))))
+                                                 versions)))
+            json/generate-string)))
 
 (defroutes routes
   (context "/api" []
-    (GET ["/:group-id", :group-id #"[^/]+"] [group-id]
+    (GET ["/groups/:group-id", :group-id #"[^/]+"] [group-id]
       (let [stats (stats/all)]
         (-> (db/jars-by-groupname group-id)
             (->> (map (fn [jar]
-                        (assoc jar :downloads (stats/download-count stats group-id (:jar_name jar))))))
-            (json/generate-string))))
-    (GET ["/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"]
-      [group-id artifact-id]
-      (let [stats (stats/all)]
-        (some-> (db/find-jar group-id artifact-id)
-                (assoc :recent_versions (db/recent-versions group-id artifact-id)
-                       :downloads (stats/download-count stats group-id artifact-id))
-                (update-in [:recent_versions] (fn [versions]
-                                                (map (fn [version]
-                                                       (assoc version :downloads (stats/download-count stats group-id artifact-id (:version version))))
-                                                     versions)))
-                (json/generate-string))))
+                        (-> jar
+                            (dissoc :id :created :promoted_at)
+                            (assoc :downloads (stats/download-count stats group-id (:jar_name jar)))))))
+            json/generate-string)))
+    (GET ["/artifacts/:artifact-id", :artifact-id #"[^/]+"] [artifact-id]
+      (get-artifact artifact-id artifact-id))
+    (GET ["/artifacts/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"] [group-id artifact-id]
+      (get-artifact group-id artifact-id))
+    (GET "/users/:username" [username]
+      (-> {:groups (db/find-groupnames username)}
+          json/generate-string))
     (ANY "*" _
       (not-found nil))))

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -6,7 +6,6 @@
             [ring.util.response :refer [response]]
             [clojars.db :as db]
             [clojars.stats :as stats]
-            [cheshire.core :as json]
             [korma.core :refer [exec-raw]]))
 
 (defn get-artifact [group-id artifact-id]
@@ -18,8 +17,7 @@
             (update-in [:recent_versions] (fn [versions]
                                             (map (fn [version]
                                                    (assoc version :downloads (stats/download-count stats group-id artifact-id (:version version))))
-                                                 versions)))
-            json/generate-string)))
+                                                 versions))))))
 
 (defn jars-by-groupname [groupname]
     (exec-raw [(str
@@ -71,4 +69,4 @@
 
 (def routes
   (-> handler
-      (wrap-restful-response :formats [:json :yaml :transit-json])))
+      (wrap-restful-response :formats [:json :edn :yaml :transit-json])))

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -131,3 +131,9 @@
       (let [path (codec/url-decode (:path-info req))]
         (or (response/file-response path {:root dir})
             (app req))))))
+
+(defn wrap-reject-double-dot [f]
+  (fn [req]
+    (if (re-find #"\.\." (:uri req))
+      {:status 400 :headers {}}
+      (f req))))

--- a/src/clojars/stats.clj
+++ b/src/clojars/stats.clj
@@ -1,14 +1,17 @@
 (ns clojars.stats
   (:require [clojars.config :as config]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.core.memoize :as memo]))
 
-(defn all []
+(defn all* []
   (let [path (str (config/config :stats-dir) "/all.edn")]
     (if (.exists (io/as-file path))
       (read (java.io.PushbackReader. (java.io.FileReader.
                                       (str (config/config :stats-dir)
                                            "/all.edn"))))
       {})))
+
+(def all (memo/ttl all* :ttl/threshold (* 60 60 1000))) ;; 1 hour
 
 (defn download-count [dls group-id artifact-id & [version]]
   (let [ds (dls [group-id artifact-id])]

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -27,7 +27,8 @@
             [clojars.routes.user :as user]
             [clojars.routes.artifact :as artifact]
             [clojars.routes.group :as group]
-            [clojars.routes.repo :as repo]))
+            [clojars.routes.repo :as repo]
+            [clojars.routes.api :as api]))
 
 (defroutes main-routes
   (GET "/" _
@@ -51,6 +52,7 @@
   ;; user routes must go after artifact routes
   ;; since they both catch /:identifier
   user/routes
+  api/routes
   (GET "/error" _ (throw (Exception. "What!? You really want an error?")))
   (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
   (ANY "*" _

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -105,7 +105,8 @@
                  :allow-anon? false
                  :unauthenticated-handler
                  (partial workflows/http-basic-deny "clojars")})
-               (repo/wrap-file (:repo config))))
+               (repo/wrap-file (:repo config))
+               (repo/wrap-reject-double-dot)))
   (-> main-routes
       (friend/authenticate
        {:credential-fn credential-fn

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -13,7 +13,8 @@
             [clojars.promote :refer [blockers]]
             [clojars.stats :as stats]
             [clojure.set :as set]
-            [ring.util.codec :refer [url-encode]]))
+            [ring.util.codec :refer [url-encode]]
+            [cheshire.core :as json]))
 
 (defn url-for [jar]
   (str (jar-url jar) "/versions/" (:version jar)))
@@ -250,4 +251,4 @@
 (defn make-latest-version-json [group-id artifact-id]
   "Return the latest version of a JAR as JSON"
   (let [jar (find-jar group-id artifact-id)]
-    (str "{\"version\":\"" (:version jar) "\"}")))
+    (json/generate-string (select-keys jar [:version]))))

--- a/test/clojars/test/integration/api.clj
+++ b/test/clojars/test/integration/api.clj
@@ -6,24 +6,23 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [kerodon.core :refer [session]]
+            [clojure.string :as string]
             [cheshire.core :as json]))
 
 (use-fixtures :once help/run-test-app #_(partial help/run-test-app :verbose))
 (use-fixtures :each help/default-fixture)
 
-(defn parse [format data]
-  (case format
-    :json (json/parse-string data keyword)
-    data))
+(defn get-api [parts & [opts]]
+  (-> (str "http://localhost:" help/test-port "/api/"
+           (str/join "/" (map name parts)))
+      (client/get opts)))
 
-(defn get-api
-  ([parts]
-   (get-api :json parts))
-  ([format parts]
-   (-> (str "http://localhost:" help/test-port "/api/"
-         (str/join "/" (map name parts)))
-     (client/get {:accept format})
-     (update-in [:body] (partial parse format)))))
+(defn get-content-type [resp]
+  (some-> resp :headers (get "content-type") (string/split #";") first))
+
+(deftest utils-test
+  (is (= (get-content-type {:headers {"content-type" "application/json"}}) "application/json"))
+  (is (= (get-content-type {:headers {"content-type" "application/json;charset=utf-8"}}) "application/json")))
 
 (deftest an-api-test
   (-> (session web/clojars-app)
@@ -32,10 +31,38 @@
   (scp valid-ssh-key "test.jar" "test-0.0.2/test.pom")
   (scp valid-ssh-key "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
   (scp valid-ssh-key "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (get-api [:groups "fake"])
-    clojure.pprint/pprint)
-  (-> (get-api [:artifacts "fake" "test"])
-    clojure.pprint/pprint)
-  (-> (get-api [:users "dantheman"])
-    clojure.pprint/pprint)
-  (is false))
+
+  (doseq [f ["application/json" "application/edn" "application/x-yaml" "application/transit+json"]]
+    (testing f
+      (is (= f (get-content-type (get-api [:groups "fake"] {:accept f}))))))
+
+  (testing "default format is json"
+    (is (= "application/json" (get-content-type (get-api [:groups "fake"])))))
+
+  (testing "list group artifacts"
+    (let [resp (get-api [:groups "fake"] {:accept :json})
+          body (json/parse-string (:body resp) true)]
+      (is (= {:latest_version "0.0.3-SNAPSHOT"
+              :latest_release "0.0.2"
+              :jar_name "test"
+              :group_name "fake"
+              :user "dantheman"}
+             (select-keys (first body) [:latest_release :latest_version :jar_name :group_name :user])))))
+
+  (testing "get artifact"
+    (let [resp (get-api [:artifacts "fake" "test"] {:accept :json})
+          body (json/parse-string (:body resp) true)]
+      (is (= {:version "0.0.2"
+              :jar_name "test"
+              :group_name "fake"
+              :user "dantheman"
+              :recent_versions [{:downloads 0 :version "0.0.3-SNAPSHOT"}
+                                {:downloads 0 :version "0.0.2"}
+                                {:downloads 0 :version "0.0.1"}]}
+             (select-keys body [:jar_name :group_name :version :recent_versions :user])))))
+
+  (testing "get user"
+    (let [resp (get-api [:users "dantheman"])
+          body (json/parse-string (:body resp) true)]
+      (is (= {:groups ["org.clojars.dantheman" "fake"]}
+             body)))))

--- a/test/clojars/test/integration/api.clj
+++ b/test/clojars/test/integration/api.clj
@@ -1,0 +1,41 @@
+(ns clojars.test.integration.api
+  (:require [clj-http.lite.client :as client]
+            [clojars.test.integration.steps :refer [register-as scp valid-ssh-key]]
+            [clojars.test.test-helper :as help]
+            [clojars.web :as web]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [kerodon.core :refer [session]]
+            [cheshire.core :as json]))
+
+(use-fixtures :once help/run-test-app #_(partial help/run-test-app :verbose))
+(use-fixtures :each help/default-fixture)
+
+(defn parse [format data]
+  (case format
+    :json (json/parse-string data keyword)
+    data))
+
+(defn get-api
+  ([parts]
+   (get-api :json parts))
+  ([format parts]
+   (-> (str "http://localhost:" help/test-port "/api/"
+         (str/join "/" (map name parts)))
+     (client/get {:accept format})
+     (update-in [:body] (partial parse format)))))
+
+(deftest an-api-test
+  (-> (session web/clojars-app)
+      (register-as "dantheman" "test@example.org" "password" valid-ssh-key))
+  (scp valid-ssh-key "test.jar" "test-0.0.1/test.pom")
+  (scp valid-ssh-key "test.jar" "test-0.0.2/test.pom")
+  (scp valid-ssh-key "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (scp valid-ssh-key "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (-> (get-api [:groups "fake"])
+    clojure.pprint/pprint)
+  (-> (get-api [:artifacts "fake" "test"])
+    clojure.pprint/pprint)
+  (-> (get-api [:users "dantheman"])
+    clojure.pprint/pprint)
+  (is false))

--- a/test/clojars/test/integration/uploads.clj
+++ b/test/clojars/test/integration/uploads.clj
@@ -8,26 +8,10 @@
             [clojars.test.test-helper :as help]
             [clojure.java.io :as io]
             [cemerick.pomegranate.aether :as aether]
-            [ring.adapter.jetty :as jetty]
             [net.cgrand.enlive-html :as enlive]
             [clojure.data.codec.base64 :as base64]))
 
-(declare test-port)
-
-(defn- run-test-app
-  [f]
-  (let [server (jetty/run-jetty
-                #(binding [*out* (java.io.StringWriter.)]
-                   (#'clojars-app %))
-                {:port 0 :join? false})
-        port (-> server .getConnectors first .getLocalPort)]
-    (with-redefs [test-port port]
-      (try
-        (f)
-        (finally
-          (.stop server))))))
-
-(use-fixtures :once run-test-app)
+(use-fixtures :once help/run-test-app)
 (use-fixtures :each help/default-fixture help/index-fixture)
 
 (deftest user-can-register-and-deploy
@@ -39,7 +23,7 @@
    :coordinates '[org.clojars.dantheman/test "1.0.0"]
    :jar-file (io/file (io/resource "test.jar"))
    :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-   :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+   :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                         :username "dantheman"
                         :password "password"}}
    :local-repo help/local-repo)
@@ -54,7 +38,7 @@
          (aether/resolve-dependencies
           :coordinates '[[org.clojars.dantheman/test "1.0.0"]]
           :repositories {"test" {:url
-                                 (str "http://localhost:" test-port "/repo")}}
+                                 (str "http://localhost:" help/test-port "/repo")}}
           :local-repo help/local-repo2)))
   (-> (session clojars-app)
       (visit "/groups/org.clojars.dantheman")
@@ -78,7 +62,7 @@
     :coordinates '[fake/test "0.0.1"]
     :jar-file (io/file (io/resource "test.jar"))
     :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-    :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+    :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                          :username "dantheman"
                          :password "password"}}
     :local-repo help/local-repo)
@@ -86,7 +70,7 @@
           (aether/resolve-dependencies
            :coordinates '[[fake/test "0.0.1"]]
            :repositories {"test" {:url
-                                  (str "http://localhost:" test-port "/repo")}}
+                                  (str "http://localhost:" help/test-port "/repo")}}
            :local-repo help/local-repo2)))
    (-> (session clojars-app)
        (visit "/groups/fake")
@@ -112,7 +96,7 @@
          :coordinates '[org.clojars.fixture/test "1.0.0"]
          :jar-file (io/file (io/resource "test.jar"))
          :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-         :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+         :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                               :username "dantheman"
                               :password "password"}}
          :local-repo help/local-repo))))
@@ -124,7 +108,7 @@
    :coordinates '[org.clojars.dantheman/test "0.0.1"]
    :jar-file (io/file (io/resource "test.jar"))
    :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-   :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+   :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                         :username "dantheman"
                         :password "password"}}
    :local-repo help/local-repo)
@@ -135,7 +119,7 @@
           :coordinates '[org.clojars.dantheman/test "0.0.1"]
           :jar-file (io/file (io/resource "test.jar"))
           :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-          :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+          :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                                :username "dantheman"
                                :password "password"}}
           :local-repo help/local-repo))))
@@ -147,7 +131,7 @@
    :coordinates '[org.clojars.dantheman/test "0.0.3-SNAPSHOT"]
    :jar-file (io/file (io/resource "test.jar"))
    :pom-file (io/file (io/resource "test-0.0.3-SNAPSHOT/test.pom"))
-   :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+   :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                         :username "dantheman"
                         :password "password"}}
    :local-repo help/local-repo)
@@ -155,7 +139,7 @@
    :coordinates '[org.clojars.dantheman/test "0.0.3-SNAPSHOT"]
    :jar-file (io/file (io/resource "test.jar"))
    :pom-file (io/file (io/resource "test-0.0.3-SNAPSHOT/test.pom"))
-   :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+   :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                         :username "dantheman"
                         :password "password"}}
    :local-repo help/local-repo))
@@ -167,7 +151,7 @@
    :coordinates '[org.clojars.dantheman/test.thing "0.0.3-SNAPSHOT"]
    :jar-file (io/file (io/resource "test.jar"))
    :pom-file (io/file (io/resource "test-0.0.3-SNAPSHOT/test.pom"))
-   :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+   :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                         :username "dantheman"
                         :password "password"}}
    :local-repo help/local-repo))
@@ -179,7 +163,7 @@
          :coordinates '[fake/test "1.0.0"]
          :jar-file (io/file (io/resource "test.jar"))
          :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-         :repository {"test" {:url (str "http://localhost:" test-port "/repo")}}
+         :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")}}
          :local-repo help/local-repo))))
 
 (deftest bad-login-cannot-deploy
@@ -188,7 +172,7 @@
          :coordinates '[fake/test "1.0.0"]
          :jar-file (io/file (io/resource "test.jar"))
          :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-         :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+         :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                               :username "guest"
                               :password "password"}}
          :local-repo help/local-repo))))
@@ -202,7 +186,7 @@
          :coordinates '[faKE/test "1.0.0"]
          :jar-file (io/file (io/resource "test.jar"))
          :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-         :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+         :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                               :username "dantheman"
                               :password "password"}}
          :local-repo help/local-repo))))
@@ -216,7 +200,7 @@
          :coordinates '[fake/test "1.α.0"]
          :jar-file (io/file (io/resource "test.jar"))
          :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
-         :repository {"test" {:url (str "http://localhost:" test-port "/repo")
+         :repository {"test" {:url (str "http://localhost:" help/test-port "/repo")
                               :username "dantheman"
                               :password "password"}}
          :local-repo help/local-repo))))


### PR DESCRIPTION
Fixes #325 

Adds two new endpoints under /api context.

The endpoints display all the columns from db. Perhaps some fields are unnecessary and we should select which fields are included?

- id  unnecessary
- created, promoted_at?

/api/:group-id:
```
[  
   {  
      "description":"an asynchronous web server",
      "downloads":0,
      "homepage":null,
      "scm":null,
      "created":1286468191604,
      "jar_name":"aleph",
      "group_name":"aleph",
      "id":4287,
      "version":"0.1.1-SNAPSHOT",
      "authors":"",
      "user":"ztellman",
      "promoted_at":null
   },
   {  
      "description":"The core data structures for Aleph.",
      "downloads":0,
      "homepage":null,
      "scm":null,
      "created":1285097390088,
      "jar_name":"core",
      "group_name":"aleph",
      "id":3985,
      "version":"0.6.0-SNAPSHOT",
      "authors":"",
      "user":"ztellman",
      "promoted_at":null
   }
]
```

/api/:group-id/:artifact-id
```
{  
   "description":"an asynchronous web server",
   "homepage":null,
   "scm":null,
   "created":1286468191604,
   "jar_name":"aleph",
   "group_name":"aleph",
   "id":4287,
   "recent_versions":[  
      {  
         "downloads":0,
         "version":"0.1.1-SNAPSHOT"
      },
      {  
         "downloads":0,
         "version":"0.1.0-SNAPSHOT"
      }
   ],
   "downloads":0,
   "version":"0.1.1-SNAPSHOT",
   "authors":"",
   "user":"ztellman",
   "promoted_at":null
}
```