### PR TITLE
Fix api jars-by-groupname performance

### DIFF
--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -20,6 +20,7 @@
             "join "
             "(select jar_name, group_name, max(created) as created "
             "from jars "
+            "where group_name = ? "
             "group by group_name, jar_name) l "
             "on j.jar_name = l.jar_name "
             "and j.group_name = l.group_name "
@@ -30,12 +31,15 @@
             "(select jar_name, group_name, max(created) as created "
             "from jars "
             "where version not like '%-SNAPSHOT' "
+            "and group_name = ? "
             "group by group_name, jar_name) r "
             "on j.jar_name = r.jar_name "
             "and j.group_name = r.group_name "
             ;; Find version for latest release
             "left join "
-            "(select jar_name, group_name, version, created from jars) as r2 "
+            "(select jar_name, group_name, version, created from jars "
+            "where group_name = ? "
+            ") as r2 "
             "on j.jar_name = r2.jar_name "
             "and j.group_name = r2.group_name "
             "and r.created = r2.created "
@@ -44,7 +48,7 @@
             "order by j.group_name asc, j.jar_name asc"]
         (remove nil?)
         (apply str))
-      (remove nil? [group-id artifact-id])]
+      (remove nil? [group-id group-id group-id group-id artifact-id])]
      :results)))
 
 (defn get-artifact [group-id artifact-id]


### PR DESCRIPTION
Sqlite explain shows that without restricting join queries by
group_name, sqlite is doing full table scans.
Quick dotimes 1000 shows improvement from 15 seconds to 800ms on my
computer.