### PR TITLE
Config change for TravisCI to build faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
+sudo: false
 language: clojure
 lein: lein2


### PR DESCRIPTION
Currently TravisCI configuration is using the old infrastructure and
every time tests run this message is displayed:

    This job ran on our legacy infrastructure. Please read our docs on how to upgrade"

see: https://travis-ci.org/ato/clojars-web/builds/83431619

This change fixes that as it allows this repo to use the new TravisCI
infrastructure to build branches and run tests faster.

For more details on TravisCI config, see: http://docs.travis-ci.com/user/migrating-from-legacy/