### PR TITLE
Replace the ring-servlet monkey patch with configuator

### DIFF
--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -5,16 +5,17 @@
             [clojars.config :refer [config configure]]
             [clojars.admin :as admin]
             [clojars.errors :as errors]
-            [clojars.ring-servlet-patch :refer [patch-ring-servlet!]])
+            [clojars.ring-servlet-patch :as patch])
   (:gen-class))
 
+
 (defn start-jetty [& [port]]
-  (patch-ring-servlet!)
   (when-let [port (or port (:port config))]
     (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" port))
     (run-jetty #'clojars-app {:host (:bind config)
-                            :port port
-                            :join? false})))
+                              :port port
+                              :join? false
+                              :configurator patch/use-status-message-header})))
 
 (defn -main [& args]
   (alter-var-root #'*read-eval* (constantly false))

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -66,8 +66,7 @@
        (report-error e#)
        (let [data# (ex-data e#)]
          {:status (or (:status data#) 403)
-          :status-message (:status-message data#)
-          :headers {}
+          :headers {"status-message" (:status-message data#)}
           :body (.getMessage e#)}))))
 
 (defmacro put-req [groupname & body]


### PR DESCRIPTION
It is difficult to determine where to have this kind of monkey
patching occur. It needs to happen for starting the production system,
starting any repl based development system, and for the integration tests.
Additionally, this kind of monkey patching is brittle if ring-jetty
changes it's implementation details. This patch removes it.

As an alternative the http server is configured with a decorator
around the HttpServletResponse. It checks for a custom header
and when it is found, it sets the status message. This could be slower
since it has a check everytime a header is set. An alternative
is to decorate the getOutputStream and getWriter with custom ones that
check on .flush and set the status beforehand.