### PR TITLE
Replace korma with yesql+HikariCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ To build a standalone jar for deploying to a server:
 
 2. Run the webapp: `java -jar target/clojars-web-*-standalone.jar`
 
-To run the application in auto-reload mode, from the console:
-
-1. Run `lein ring server`
-
-and that's it, it should automatically open a browser in [localhost:3000](http://localhost:3000).
-
 If you'd like to run it out of an editor/IDE environment you can
 probably eval a call to the `-main` function in
 `src/clojars/main.clj`.

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  [org.clojure/tools.nrepl "0.2.11"]
                  [org.bouncycastle/bcpg-jdk15on "1.47"]
                  [mvxcvi/clj-pgp "0.8.0"]]
-  :profiles {:dev {:dependencies [[kerodon "0.0.7"]
+  :profiles {:dev {:dependencies [[kerodon "0.7.0"]
                                   [clj-http-lite "0.2.1"]]
                    :resource-paths ["local-resources"]}}
   :plugins [[lein-ring "0.8.5"]]
@@ -49,3 +49,4 @@
                   ["change" "version" "leiningen.release/bump-version"]
                   ["vcs" "commit"]
                   ["vcs" "push"]])
+

--- a/project.clj
+++ b/project.clj
@@ -37,9 +37,7 @@
   :profiles {:dev {:dependencies [[kerodon "0.7.0"]
                                   [clj-http-lite "0.2.1"]]
                    :resource-paths ["local-resources"]}}
-  :plugins [[lein-ring "0.8.5"]]
   :aliases {"migrate" ["run" "-m" "clojars.db.migrate"]}
-  :ring {:handler clojars.web/clojars-app}
   :main clojars.main
   :min-lein-version "2.0.0"
   :release-tasks [["vcs" "assert-committed"]

--- a/project.clj
+++ b/project.clj
@@ -15,8 +15,7 @@
                  [ring-middleware-format "0.5.0"]
                  [hiccup "1.0.3"]
                  [cheshire "5.4.0"]
-                 [korma "0.3.0-beta10"]
-                 [org.xerial/sqlite-jdbc "3.7.2"]
+                 [org.xerial/sqlite-jdbc "3.8.11.2"]
                  [org.apache.commons/commons-email "1.2"]
                  [commons-codec "1.6"]
                  [net.cgrand/regex "1.0.1"
@@ -33,7 +32,8 @@
                  [clucy "0.3.0"]
                  [org.clojure/tools.nrepl "0.2.11"]
                  [org.bouncycastle/bcpg-jdk15on "1.47"]
-                 [mvxcvi/clj-pgp "0.8.0"]]
+                 [mvxcvi/clj-pgp "0.8.0"]
+                 [yesql "0.5.1"]]
   :profiles {:dev {:dependencies [[kerodon "0.7.0"]
                                   [clj-http-lite "0.2.1"]]
                    :resource-paths ["local-resources"]}}

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,9 @@
                  [org.clojure/tools.nrepl "0.2.11"]
                  [org.bouncycastle/bcpg-jdk15on "1.47"]
                  [mvxcvi/clj-pgp "0.8.0"]
-                 [yesql "0.5.1"]]
+                 [yesql "0.5.1"]
+                 [com.zaxxer/HikariCP "2.4.1"]
+                 [org.slf4j/slf4j-nop "1.7.7"]]
   :profiles {:dev {:dependencies [[kerodon "0.7.0"]
                                   [clj-http-lite "0.2.1"]]
                    :resource-paths ["local-resources"]}}

--- a/resources/queries/sqlite-queryfile.sql
+++ b/resources/queries/sqlite-queryfile.sql
@@ -1,0 +1,346 @@
+--name: find-user
+SELECT *
+FROM users
+WHERE user = :username
+LIMIT 1;
+
+--name: find-user-by-user-or-email
+SELECT *
+FROM users
+WHERE (
+  user = :username_or_email
+  OR
+  email = :username_or_email
+)
+LIMIT 1;
+
+--name: find-user-by-password-reset-code
+SELECT *
+FROM users
+WHERE (
+      password_reset_code = :reset_code
+      AND
+      password_reset_code_created_at >= :reset_code_created_at
+)
+LIMIT 1;
+
+--name: find-groupnames
+SELECT name
+FROM groups
+WHERE user = :username;
+
+--name: group-membernames
+SELECT user
+FROM groups
+WHERE name = :groupname;
+
+--name: group-keys
+SELECT users.pgp_key
+FROM groups
+INNER JOIN users
+ON users.user = groups.user
+WHERE groups.name = :groupname;
+
+--name: jars-by-username
+SELECT j.*
+FROM jars j
+JOIN (
+  SELECT group_name, jar_name, MAX(created) AS created
+  FROM jars
+  GROUP BY group_name, jar_name
+) l
+ON (
+   j.group_name = l.group_name
+   AND
+   j.jar_name = l.jar_name
+   AND
+   j.created = l.created
+)
+WHERE j.user = :username
+ORDER BY j.group_name ASC, j.jar_name ASC;
+
+--name: jars-by-groupname
+SELECT j.*
+FROM jars j
+JOIN (
+  SELECT  jar_name, MAX(created) AS created
+  FROM jars
+  GROUP BY group_name, jar_name
+) l
+ON (
+   j.jar_name = l.jar_name
+   AND
+   j.created = l.created
+)
+WHERE j.group_name = :groupname
+ORDER BY j.group_name ASC, j.jar_name ASC;
+
+--name: recent-versions
+SELECT DISTINCT(version)
+FROM jars
+WHERE (
+  group_name = :groupname
+  AND
+  jar_name = :jarname
+)
+ORDER BY created DESC;
+
+--name: recent-versions-limit
+SELECT DISTINCT(version)
+FROM jars
+WHERE (
+  group_name = :groupname
+  AND
+  jar_name = :jarname
+)
+ORDER BY created DESC
+LIMIT :num;
+
+--name: count-versions
+SELECT COUNT(DISTINCT version) AS count
+FROM jars
+WHERE (
+  group_name = :groupname
+  AND
+  jar_name = :jarname
+);
+
+--name: recent-jars
+SELECT j.* 
+FROM jars j
+JOIN (
+  SELECT group_name, jar_name, MAX(created) AS created
+  FROM jars
+  GROUP BY group_name, jar_name
+) l
+ON (
+  j.group_name = l.group_name
+  AND
+  j.jar_name = l.jar_name
+  AND
+  j.created = l.created
+)
+ORDER BY l.created DESC
+LIMIT 6;
+
+--name: jar-exists
+SELECT EXISTS(
+  SELECT 1
+  FROM jars
+  WHERE (
+    group_name = :groupname
+    AND
+    jar_name = :jarname
+  )
+);
+
+--name: find-jar
+SELECT *
+FROM jars
+WHERE (
+  group_name = :groupname
+  AND
+  jar_name = :jarname
+)
+ORDER BY version LIKE '%-SNAPSHOT' ASC, created DESC
+LIMIT 1;
+
+--name: find-jar-versioned
+SELECT *
+FROM jars
+WHERE (
+  group_name = :groupname
+  AND
+  jar_name = :jarname
+  AND
+  version = :version
+)
+ORDER BY created DESC
+LIMIT 1;
+
+--name: all-projects
+SELECT DISTINCT group_name, jar_name
+FROM jars
+ORDER BY group_name ASC, jar_name ASC
+LIMIT :num
+OFFSET :offset;
+
+--name: count-all-projects
+SELECT COUNT(*) AS count
+FROM (
+  SELECT DISTINCT group_name, jar_name
+  FROM jars
+);
+
+--name: count-projects-before
+SELECT COUNT(*) AS count
+FROM (
+  SELECT DISTINCT group_name, jar_name
+  FROM jars
+  ORDER BY group_name, jar_name
+)
+WHERE group_name || '/' || jar_name < :s;
+
+--name: insert-user!
+INSERT INTO 'users' (email, user, password, pgp_key, created, ssh_key, salt)
+VALUES (:email, :username, :password, :pgp_key, :created, '', '');
+
+--name: insert-group!
+INSERT INTO 'groups' (name, user)
+VALUES (:groupname, :username);
+
+--name: update-user!
+UPDATE users
+SET email = :email, user = :username, pgp_key = :pgp_key, password = :password
+WHERE user = :account;
+
+--name: update-user-password!
+UPDATE users
+SET password = :password, password_reset_code = NULL, password_reset_code_created_at = NULL
+WHERE password_reset_code = :reset_code;
+
+--name: set-password-reset-code!
+UPDATE users
+SET password_reset_code = :reset_code, password_reset_code_created_at = :reset_code_created_at
+WHERE (
+  user = :username_or_email
+  OR
+  email = :username_or_email
+);
+
+--name: find-groups-jars-information
+SELECT j.jar_name, j.group_name, homepage, description, user,
+j.version AS latest_version, r2.version AS latest_release
+FROM jars j
+-- Find the latest version
+JOIN
+(SELECT jar_name, group_name, MAX(created) AS created
+FROM jars
+WHERE group_name = :group_id
+GROUP BY group_name, jar_name) l
+ON j.jar_name = l.jar_name
+AND j.group_name = l.group_name
+-- Find basic info for latest version
+AND j.created = l.created
+-- Find the created ts for latest release
+LEFT JOIN
+(SELECT jar_name, group_name, MAX(created) AS created
+FROM jars
+WHERE version NOT LIKE '%-SNAPSHOT'
+AND group_name = :group_id
+GROUP BY group_name, jar_name) r
+ON j.jar_name = r.jar_name
+AND j.group_name = r.group_name
+-- Find version for latest release
+LEFT JOIN
+(SELECT jar_name, group_name, version, created FROM jars
+WHERE group_name = :group_id
+) AS r2
+ON j.jar_name = r2.jar_name
+AND j.group_name = r2.group_name
+AND r.created = r2.created
+WHERE j.group_name = :group_id
+ORDER BY j.group_name ASC, j.jar_name ASC;
+
+--name: find-jars-information
+SELECT j.jar_name, j.group_name, homepage, description, user,
+j.version AS latest_version, r2.version AS latest_release
+FROM jars j
+-- Find the latest version
+JOIN
+(SELECT jar_name, group_name, MAX(created) AS created
+FROM jars
+WHERE group_name = :group_id
+AND jar_name = :artifact_id
+GROUP BY group_name, jar_name) l
+ON j.jar_name = l.jar_name
+AND j.group_name = l.group_name
+-- Find basic info for latest version
+AND j.created = l.created
+-- Find the created ts for latest release
+LEFT JOIN
+(SELECT jar_name, group_name, MAX(created) AS created
+FROM jars
+WHERE version NOT LIKE '%-SNAPSHOT'
+AND group_name = :group_id
+AND jar_name = :artifact_id
+GROUP BY group_name, jar_name) r
+ON j.jar_name = r.jar_name
+AND j.group_name = r.group_name
+-- Find version for latest release
+LEFT JOIN
+(SELECT jar_name, group_name, version, created FROM jars
+WHERE group_name = :group_id
+AND jar_name = :artifact_id
+) AS r2
+ON j.jar_name = r2.jar_name
+AND j.group_name = r2.group_name
+AND r.created = r2.created
+WHERE j.group_name = :group_id
+AND j.jar_name = :artifact_id
+ORDER BY j.group_name ASC, j.jar_name ASC;
+            
+--name: add-member!
+INSERT INTO groups (name, user, added_by)
+VALUES (:groupname, :username, :added_by);
+
+--name: add-jar!
+INSERT INTO jars (group_name, jar_name, version, user, created, description, homepage, authors)
+VALUES (:groupname, :jarname, :version, :user, :created, :description, :homepage, :authors);
+
+--name: promote!
+UPDATE jars
+SET promoted_at = :promoted_at
+WHERE (
+  group_name = :group_id
+  AND
+  jar_name = :artifact_id
+  AND
+  version = :version
+);
+
+--name: promoted
+SELECT promoted_at
+FROM jars
+WHERE (
+  group_name = :group_id
+  AND
+  jar_name = :artifact_id
+  AND
+  version = :version
+);
+
+--name: delete-groups-jars!
+DELETE FROM jars
+WHERE group_name = :group_id;
+
+--name: delete-jars!
+DELETE FROM jars
+WHERE (
+  group_name = :group_id
+  AND
+  jar_name = :jar_id
+);
+
+--name: delete-jar-version!
+DELETE FROM jars
+WHERE (
+  group_name = :group_id
+  AND
+  jar_name = :jar_id
+  AND
+  version = :version
+);
+
+--name: delete-group!
+DELETE FROM groups
+WHERE name = :group_id;
+
+--name: clear-groups!
+DELETE FROM groups;
+
+--name: clear-jars!
+DELETE FROM jars;
+
+--name: clear-users!
+DELETE FROM users;

--- a/src/clojars/admin.clj
+++ b/src/clojars/admin.clj
@@ -1,15 +1,18 @@
 (ns clojars.admin
-  (:require [clojars.config :refer [config]]
-            [clojars.db :as db]
-            [clojars.search :as search]
+  (:require [clojars
+             [config :refer [config]]
+             [db :as db]
+             [search :as search]]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.nrepl.server :as nrepl])
-  (:import org.apache.commons.io.FileUtils
-           java.text.SimpleDateFormat))
+  (:import java.text.SimpleDateFormat
+           org.apache.commons.io.FileUtils))
 
 (defn current-date-str []
   (.format (SimpleDateFormat. "yyyyMMdd") (db/get-time)))
+
+(def ^:dynamic *db*)
 
 (defn repo->backup [parts]
   (let [backup (doto (io/file (:deletion-backup-dir config))
@@ -34,22 +37,22 @@
        "     if no version is provided"])))
 
 (defn delete-group [group-id]
-  (if (seq (db/group-membernames group-id))
+  (if (seq (db/group-membernames *db* group-id))
     (do
       (println "Giving you a fn to delete group" group-id)
       (fn []
         (println "Deleting" group-id)
         (repo->backup [group-id])
-        (db/delete-jars group-id)
-        (db/delete-groups group-id)
+        (db/delete-jars *db* group-id)
+        (db/delete-groups *db* group-id)
         (search/delete-from-index group-id)))
     (println "No group found under" group-id)))
 
 (defn delete-jars [group-id jar-id & [version]]
   (let [pretty-coords (format "%s/%s %s" group-id jar-id (or version "(all versions)"))]
     (if-let [description (:description (if version
-                                         (db/find-jar group-id jar-id version)
-                                         (db/find-jar group-id jar-id)))]
+                                         (db/find-jar *db* group-id jar-id version)
+                                         (db/find-jar *db* group-id jar-id)))]
       (do
         (println "Giving you a fn to delete jars that match" pretty-coords)
         (when-not
@@ -58,11 +61,24 @@
         (fn []
           (println "Deleting" pretty-coords)
           (repo->backup [group-id jar-id version])
-          (apply db/delete-jars group-id jar-id (if version [version] []))
+          (apply db/delete-jars *db* group-id jar-id (if version [version] []))
           (search/delete-from-index group-id jar-id)))
       (println "No artifacts found under" group-id jar-id version))))
 
-(defn init []
+
+(defn handler [mapping]
+  (nrepl/default-handler
+    (with-meta
+      (fn [h]
+        (fn [{:keys [session] :as msg}]
+          (swap! session merge mapping)
+          (h msg)))
+      {:clojure.tools.nrepl.middleware/descriptor {:requires #{"clone"}
+                                                   :expects #{"eval"}}})))
+
+(defn init [db]
   (when-let [port (:nrepl-port config)]
     (printf "clojars-web: starting nrepl on localhost:%s\n" port)
-    (nrepl/start-server :port port :bind "127.0.0.1")))
+    (nrepl/start-server :port port
+                        :bind "127.0.0.1"
+                        :handler (handler {#'*db* db}))))

--- a/src/clojars/auth.clj
+++ b/src/clojars/auth.clj
@@ -9,13 +9,13 @@
   `(let [~'account (:username (friend/current-authentication))]
      ~body))
 
-(defn authorized? [account group]
+(defn authorized? [db account group]
   (if account
-    (let [names (group-membernames group)]
+    (let [names (group-membernames db group)]
       (or (some #{account} names) (empty? names)))))
 
-(defmacro require-authorization [group & body]
-  `(if (authorized? ~'account ~group)
+(defmacro require-authorization [db group & body]
+  `(if (authorized? ~db ~'account ~group)
      (do ~@body)
      (friend/throw-unauthorized friend/*identity*
                                 {:cemerick.friend/exprs (quote [~@body])

--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -4,41 +4,44 @@
             [clojars.config :refer [config]])
   (:import (java.sql Timestamp)))
 
-(defn initial-schema []
+(defn initial-schema [trans]
   (doseq [cmd (.split (slurp "clojars.sql") ";\n\n")]
     ;; needs to succeed even if tables exist since this migration
     ;; hasn't been recorded in extant DBs before migrations were introduced
-    (try (sql/do-commands cmd)
+    (try (sql/db-do-commands trans cmd)
          (catch java.sql.BatchUpdateException _))))
 
-(defn add-promoted-field []
-  (sql/do-commands "ALTER TABLE jars ADD COLUMN promoted_at DATE"))
+(defn add-promoted-field [trans]
+  (sql/db-do-commands trans "ALTER TABLE jars ADD COLUMN promoted_at DATE"))
 
-(defn add-jars-index []
+(defn add-jars-index [trans]
   ;; speed up the front page and selects for jars by name
-  (sql/do-commands (str "CREATE INDEX IF NOT EXISTS jars_idx0 "
+  (sql/db-do-commands trans
+                      (str "CREATE INDEX IF NOT EXISTS jars_idx0 "
                         "ON jars (group_name, jar_name, created DESC)")))
 
-(defn add-pgp-key []
-  (sql/do-commands "ALTER TABLE users ADD COLUMN pgp_key TEXT"))
+(defn add-pgp-key [trans]
+  (sql/db-do-commands trans "ALTER TABLE users ADD COLUMN pgp_key TEXT"))
 
-(defn add-added-by []
-  (sql/do-commands "ALTER TABLE groups ADD COLUMN added_by TEXT"))
+(defn add-added-by [trans]
+  (sql/db-do-commands trans "ALTER TABLE groups ADD COLUMN added_by TEXT"))
 
-(defn add-password-reset-code []
-  (sql/do-commands "ALTER TABLE users ADD COLUMN password_reset_code TEXT"))
+(defn add-password-reset-code [trans]
+  (sql/db-do-commands trans "ALTER TABLE users ADD COLUMN password_reset_code TEXT"))
 
-(defn add-password-reset-code-created-at []
-  (sql/do-commands "ALTER TABLE users ADD COLUMN password_reset_code_created_at DATE"))
+(defn add-password-reset-code-created-at [trans]
+  (sql/db-do-commands trans "ALTER TABLE users ADD COLUMN password_reset_code_created_at DATE"))
 
 ;; migrations mechanics
 
-(defn run-and-record [migration]
+(defn run-and-record [migration trans]
   (println "Running migration:" (:name (meta migration)))
-  (migration)
-  (sql/insert-values "migrations" [:name :created_at]
-                     [(str (:name (meta migration)))
-                      (Timestamp. (System/currentTimeMillis))]))
+  (migration trans)
+  (sql/insert! trans
+               "migrations"
+               [:name :created_at]
+               [(str (:name (meta migration)))
+                (Timestamp. (System/currentTimeMillis))]))
 
 (defn- ensure-db-directory-exists [db]
   (when-not (.exists (io/file db))
@@ -46,18 +49,20 @@
 
 (defn migrate [& migrations]
   (ensure-db-directory-exists (:subname (config :db)))
-  (sql/with-connection (config :db)
-    (try (sql/create-table "migrations"
-                           [:name :varchar "NOT NULL"]
-                           [:created_at :timestamp
-                            "NOT NULL"  "DEFAULT CURRENT_TIMESTAMP"])
-         (catch Exception _))
-    (sql/transaction
-     (let [has-run? (sql/with-query-results run ["SELECT name FROM migrations"]
-                      (set (map :name run)))]
-       (doseq [m migrations
-               :when (not (has-run? (str (:name (meta m)))))]
-         (run-and-record m))))))
+  (try (sql/db-do-commands (:db config)
+                           (sql/create-table-ddl "migrations"
+                                                 [:name :varchar "NOT NULL"]
+                                                 [:created_at :timestamp
+                                                  "NOT NULL"  "DEFAULT CURRENT_TIMESTAMP"])) 
+       (catch Exception _))
+  (sql/with-db-transaction [trans (:db config)]
+    (let [has-run? (sql/query trans ["SELECT name FROM migrations"]
+                              :row-fn :name
+                              :result-set-fn set)]
+      (doseq [m migrations
+              :when (not (has-run? (str (:name (meta m)))))]
+        (run-and-record m trans)))))
+
 
 (defn -main []
   (migrate #'initial-schema

--- a/src/clojars/db/sql.clj
+++ b/src/clojars/db/sql.clj
@@ -1,0 +1,6 @@
+(ns clojars.db.sql
+  (:require [yesql.core :refer [defqueries]]))
+
+;; hack due to https://github.com/krisajenkins/yesql/issues/118
+(defqueries "queries/sqlite-queryfile.sql")
+

--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -5,16 +5,16 @@
             [clojars.search :as search]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [korma.core :refer [delete]])
+            [clojars.db.sql :as sql])
   (:import [org.apache.maven.artifact.repository.metadata Metadata Versioning]
            [org.apache.maven.artifact.repository.metadata.io.xpp3
             MetadataXpp3Reader
             MetadataXpp3Writer]))
 
 (defn reset-db! []
-  (delete db/jars)
-  (delete db/groups)
-  (delete db/users))
+  (sql/clear-jars! {} {:connection (:db config)})
+  (sql/clear-groups!{} {:connection (:db config)})
+  (sql/clear-users! {} {:connection (:db config)}))
 
 (defn add-test-users
   "Adds n test users of the form test0/test0."

--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -11,20 +11,20 @@
             MetadataXpp3Reader
             MetadataXpp3Writer]))
 
-(defn reset-db! []
-  (sql/clear-jars! {} {:connection (:db config)})
-  (sql/clear-groups!{} {:connection (:db config)})
-  (sql/clear-users! {} {:connection (:db config)}))
+(defn reset-db! [db]
+  (sql/clear-jars! {} {:connection db})
+  (sql/clear-groups! {} {:connection db})
+  (sql/clear-users! {} {:connection db}))
 
 (defn add-test-users
   "Adds n test users of the form test0/test0."
-  [n]
+  [db n]
   (mapv #(let [name (str "test" %)]
-           (if (db/find-user name)
+           (if (db/find-user db name)
              (println "User" name "already exists")
              (do
                (printf "Adding user %s/%s\n" name name)
-               (db/add-user (str name "@example.com") name name "")))
+               (db/add-user db (str name "@example.com") name name "")))
            name)
     (range n)))
 
@@ -59,7 +59,7 @@
 
 (defn import-repo
   "Builds a dev db from the contents of the repo."
-  [repo stats-dir users]
+  [db repo stats-dir users]
   (let [group-artifact-pattern (re-pattern (str repo "/(.*)/([^/]*)$"))
         stats-file (io/file stats-dir "all.edn")]
     (->>
@@ -70,10 +70,11 @@
                   [_ group-path artifact-id] (re-find group-artifact-pattern (.getPath parent))
                   version (.getName version-dir)
                   group-id (str/lower-case (str/replace group-path "/" "."))
-                  user (or (first (db/group-membernames group-id)) (rand-nth users))]]
-        (when-not (db/find-jar group-id artifact-id version)
+                  user (or (first (db/group-membernames db group-id)) (rand-nth users))]]
+        (when-not (db/find-jar db group-id artifact-id version)
           (printf "Importing %s/%s %s (user: %s)\n" group-id artifact-id version user)
-          (db/add-jar user {:group group-id
+          (db/add-jar db
+                      user {:group group-id
                             :name artifact-id
                             :version version
                             :description (format "Description for %s/%s" group-id artifact-id)
@@ -90,8 +91,7 @@
     (println "Wrote download stats to" (.getAbsolutePath stats-file))))
 
 (defn -main []
-  (let [db (-> config :db :subname)
-        {:keys [repo stats-dir]} config]
+  (let [{:keys [repo stats-dir db]} config]
     (println "NOTE: this will clear the contents of" db
       "and import all of the projects in" repo "into the db.\n")
     (print "Are you sure you want to continue? [y/N] ")
@@ -100,12 +100,11 @@
       (println "Aborting.")
       (System/exit 1))
     (println "==> Clearing the" db "db...")
-    (reset-db!)
+    (reset-db! db)
     (println "==> Creating 10 test users...")
-    (let [test-users (add-test-users 10)]
+    (let [test-users (add-test-users db 10)]
       (println "==> Importing" repo "into the db...")
-      (import-repo repo stats-dir test-users))
+      (import-repo db repo stats-dir test-users))
     (println "==> Indexing" repo "...")
     (search/index-repo repo))
-  ;; something (korma's thread pool?) keeps us from exiting normally
-  (System/exit 0))
+  (.shutdown (db/write-executor)))

--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -6,17 +6,18 @@
             [clojars.db :refer [add-user]]
             [valip.core :refer [validate]]))
 
-(defn register [{:keys [email username password confirm pgp-key]}]
+(defn register [db {:keys [email username password confirm pgp-key]}]
   (if-let [errors (apply validate {:email email
                                    :username username
                                    :password password
                                    :pgp-key pgp-key}
-                         (new-user-validations confirm))]
+                         (new-user-validations db confirm))]
     (response (register-form (apply concat (vals errors)) email username))
-    (do (add-user email username password pgp-key)
+    (do (add-user db email username password pgp-key)
         (workflow/make-auth {:identity username :username username}))))
 
-(defn workflow [{:keys [uri request-method params]}]
-  (when (and (= uri "/register")
-             (= request-method :post))
-    (register params)))
+(defn workflow [db]
+  (fn [{:keys [uri request-method params]}]
+    (when (and (= uri "/register")
+               (= request-method :post))
+      (register db params))))

--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -1,28 +1,29 @@
 (ns clojars.main
-  (:require [ring.adapter.jetty :refer [run-jetty]]
-            [clojars.web :refer [clojars-app]]
-            [clojars.promote :as promote]
-            [clojars.config :refer [config configure]]
-            [clojars.admin :as admin]
-            [clojars.errors :as errors]
-            [clojars.ring-servlet-patch :as patch])
+  (:require [clojars
+             [admin :as admin]
+             [config :refer [config configure]]
+             [errors :as errors]
+             [ring-servlet-patch :as patch]
+             [web :refer [clojars-app]]]
+            [ring.adapter.jetty :refer [run-jetty]])
   (:gen-class))
 
-
-(defn start-jetty [& [port]]
+(defn start-jetty [db & [port]]
   (when-let [port (or port (:port config))]
     (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" port))
-    (run-jetty #'clojars-app {:host (:bind config)
-                              :port port
-                              :join? false
-                              :configurator patch/use-status-message-header})))
+    (run-jetty (#'clojars-app db)
+               {:host (:bind config)
+                :port port
+                :join? false
+                :configurator patch/use-status-message-header})))
 
 (defn -main [& args]
   (alter-var-root #'*read-eval* (constantly false))
   (configure args)
   (errors/register-global-exception-handler!)
-  (start-jetty)
-  (admin/init))
+  (let [db (:db config)]
+    (start-jetty db)
+    (admin/init db)))
 
 (comment
   (def server (start-jetty 8080))

--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -6,6 +6,7 @@
              [ring-servlet-patch :as patch]
              [web :refer [clojars-app]]]
             [ring.adapter.jetty :refer [run-jetty]])
+  (:import [com.zaxxer.hikari HikariConfig HikariDataSource])
   (:gen-class))
 
 (defn start-jetty [db & [port]]
@@ -17,11 +18,20 @@
                 :join? false
                 :configurator patch/use-status-message-header})))
 
+(defn jdbc-url [db-config]
+  (if (string? db-config)
+    (if (.startsWith db-config "jdbc:")
+      db-config
+      (str "jdbc:" db-config))
+    (let [{:keys [subprotocol subname]} db-config]
+      (format "jdbc:%s:%s" subprotocol subname))))
+
 (defn -main [& args]
   (alter-var-root #'*read-eval* (constantly false))
   (configure args)
   (errors/register-global-exception-handler!)
-  (let [db (:db config)]
+  (let [url (jdbc-url (:db config))
+        db {:datasource (HikariDataSource. (doto (HikariConfig.) (.setJdbcUrl url)))}]
     (start-jetty db)
     (admin/init db)))
 

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -1,18 +1,19 @@
 (ns clojars.routes.api
-  (:require [clojure.set :refer [rename-keys]]
-            [compojure.core :refer [GET ANY defroutes context]]
-            [compojure.route :refer [not-found]]
+  (:require [clojars
+             [db :as db]
+             [stats :as stats]]
+            [compojure
+             [core :as compojure :refer [ANY context GET]]
+             [route :refer [not-found]]]
             [ring.middleware.format-response :refer [wrap-restful-response]]
-            [ring.util.response :refer [response]]
-            [clojars.db :as db]
-            [clojars.stats :as stats]))
+            [ring.util.response :refer [response]]))
 
-(defn get-artifact [group-id artifact-id]
-  (if-let [artifact (first (db/find-jars-information group-id artifact-id))]
+(defn get-artifact [db group-id artifact-id]
+  (if-let [artifact (first (db/find-jars-information db group-id artifact-id))]
     (let [stats (stats/all)]
       (-> artifact
         (assoc
-          :recent_versions (db/recent-versions group-id artifact-id)
+          :recent_versions (db/recent-versions db group-id artifact-id)
           :downloads (stats/download-count stats group-id artifact-id))
         (update-in [:recent_versions]
           (fn [versions]
@@ -23,28 +24,29 @@
         response))
     (not-found nil)))
 
-(defroutes handler
-  (context "/api" []
-    (GET ["/groups/:group-id", :group-id #"[^/]+"] [group-id]
-      (if-let [jars (seq (db/find-jars-information group-id))]
-        (let [stats (stats/all)]
-          (response
-            (map (fn [jar]
-                   (assoc jar
-                     :downloads (stats/download-count stats group-id (:jar_name jar))))
-              jars)))
-        (not-found nil)))
-    (GET ["/artifacts/:artifact-id", :artifact-id #"[^/]+"] [artifact-id]
-      (get-artifact artifact-id artifact-id))
-    (GET ["/artifacts/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"] [group-id artifact-id]
-      (get-artifact group-id artifact-id))
-    (GET "/users/:username" [username]
-      (if-let [groups (seq (db/find-groupnames username))]
-        (response {:groups groups})
-        (not-found nil)))
-    (ANY "*" _
-      (not-found nil))))
+(defn handler [db]
+  (compojure/routes
+   (context "/api" []
+            (GET ["/groups/:group-id", :group-id #"[^/]+"] [group-id]
+                 (if-let [jars (seq (db/find-jars-information db group-id))]
+                   (let [stats (stats/all)]
+                     (response
+                      (map (fn [jar]
+                             (assoc jar
+                                    :downloads (stats/download-count stats group-id (:jar_name jar))))
+                           jars)))
+                   (not-found nil)))
+            (GET ["/artifacts/:artifact-id", :artifact-id #"[^/]+"] [artifact-id]
+                 (get-artifact db artifact-id artifact-id))
+            (GET ["/artifacts/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"] [group-id artifact-id]
+                 (get-artifact db group-id artifact-id))
+            (GET "/users/:username" [username]
+                 (if-let [groups (seq (db/find-groupnames db username))]
+                   (response {:groups groups})
+                   (not-found nil)))
+            (ANY "*" _
+                 (not-found nil)))))
 
-(def routes
-  (-> handler
+(defn routes [db]
+  (-> (handler db)
       (wrap-restful-response :formats [:json :edn :yaml :transit-json])))

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -55,10 +55,10 @@
       maven/pom-to-map
       (merge info)))
 
-(defn- body-and-add-pom [body filename info account]
+(defn- body-and-add-pom [db body filename info account]
   (if (pom? filename)
     (let [contents (slurp body)]
-      (db/add-jar account (get-pom-info contents info))
+      (db/add-jar db account (get-pom-info contents info))
       contents)
     body))
 
@@ -74,9 +74,11 @@
           :headers {"status-message" (:status-message data#)}
           :body (.getMessage e#)}))))
 
-(defmacro put-req [groupname & body]
+
+(defmacro put-req [db groupname & body]
   `(with-account
      (require-authorization
+      ~db
       ~groupname
       (with-error-handling
         ~@body))))
@@ -129,49 +131,52 @@
                   :file filename}
                  (ex-data e)))))))
 
-(defn- handle-versioned-upload [body group artifact version filename]
+(defn- handle-versioned-upload [db body group artifact version filename]
   (let [groupname (string/replace group "/" ".")]
     (put-req
+      db
       groupname
       (let [file (io/file (config :repo) group artifact version filename)
             info {:group groupname
                   :name  artifact
                   :version version}]
         (validate-deploy groupname artifact version filename)
-        (db/check-and-add-group account groupname)
+        (db/check-and-add-group db account groupname)
 
-        (try-save-to-file file (body-and-add-pom body filename info account))
+        (try-save-to-file file (body-and-add-pom db body filename info account))
         (when (pom? filename)
           (with-open [index (clucy/disk-index (config :index-path))]
             (search/index-pom index file)))))))
 
 ;; web handlers
-(defroutes routes
-  (PUT ["/:group/:artifact/:file"
-        :group #".+" :artifact #"[^/]+" :file #"maven-metadata\.xml[^/]*"]
-       {body :body {:keys [group artifact file]} :params}
-       (if (snapshot-version? artifact)
-         ;; SNAPSHOT metadata will hit this route, but should be
-         ;; treated as a versioned file upload.
-         ;; See: https://github.com/ato/clojars-web/issues/319
-         (let [version artifact
-               group-parts (string/split group #"/")
-               group (string/join "/" (butlast group-parts))
-               artifact (last group-parts)]
-           (handle-versioned-upload body group artifact version file))
-         (let [groupname (string/replace group "/" ".")]
-           (put-req
+(defn routes [db]
+  (compojure/routes
+   (PUT ["/:group/:artifact/:file"
+         :group #".+" :artifact #"[^/]+" :file #"maven-metadata\.xml[^/]*"]
+        {body :body {:keys [group artifact file]} :params}
+        (if (snapshot-version? artifact)
+          ;; SNAPSHOT metadata will hit this route, but should be
+          ;; treated as a versioned file upload.
+          ;; See: https://github.com/ato/clojars-web/issues/319
+          (let [version artifact
+                group-parts (string/split group #"/")
+                group (string/join "/" (butlast group-parts))
+                artifact (last group-parts)]
+            (handle-versioned-upload db body group artifact version file))
+          (let [groupname (string/replace group "/" ".")]
+            (put-req
+             db
              groupname
              (let [file (io/file (config :repo) group artifact file)]
-               (db/check-and-add-group account groupname)
+               (db/check-and-add-group db account groupname)
                (try-save-to-file file body))))))
-  (PUT ["/:group/:artifact/:version/:filename"
-        :group #"[^\.]+" :artifact #"[^/]+" :version #"[^/]+"
-        :filename #"[^/]+(\.pom|\.jar|\.sha1|\.md5|\.asc)$"]
-       {body :body {:keys [group artifact version filename]} :params}
-       (handle-versioned-upload body group artifact version filename))
-  (PUT "*" _ {:status 400 :headers {}})
-  (not-found "Page not found"))
+   (PUT ["/:group/:artifact/:version/:filename"
+         :group #"[^\.]+" :artifact #"[^/]+" :version #"[^/]+"
+         :filename #"[^/]+(\.pom|\.jar|\.sha1|\.md5|\.asc)$"]
+        {body :body {:keys [group artifact version filename]} :params}
+        (handle-versioned-upload db body group artifact version filename))
+   (PUT "*" _ {:status 400 :headers {}})
+   (not-found "Page not found")))
 
 (defn wrap-file [app dir]
   (fn [req]

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -1,37 +1,38 @@
 (ns clojars.routes.user
-  (:require [compojure.core :refer [GET POST defroutes]]
+  (:require [clojars.db :as db]
             [clojars.auth :as auth]
             [clojars.web.user :as view]
-            [clojars.db :as db]))
+            [compojure.core :as compojure :refer [GET POST]]))
 
-(defn show [username]
-  (if-let [user (db/find-user username)]
+(defn show [db username]
+  (if-let [user (db/find-user db username)]
     (auth/try-account
-     (view/show-user account user))))
+     (view/show-user db account user))))
 
-(defroutes routes
-  (GET "/profile" {:keys [flash]}
-       (auth/with-account
-         (view/profile-form account flash)))
-  (POST "/profile" {:keys [params]}
+(defn routes [db]
+  (compojure/routes
+   (GET "/profile" {:keys [flash]}
         (auth/with-account
-          (view/update-profile account params)))
+          (view/profile-form account (db/find-user db account) flash)))
+   (POST "/profile" {:keys [params]}
+         (auth/with-account
+           (view/update-profile db account params)))
 
-  (GET "/register" _
-       (view/register-form))
+   (GET "/register" _
+        (view/register-form))
 
-  (GET "/forgot-password" _
-       (view/forgot-password-form))
-  (POST "/forgot-password" {:keys [params]}
-        (view/forgot-password params))
+   (GET "/forgot-password" _
+        (view/forgot-password-form))
+   (POST "/forgot-password" {:keys [params]}
+         (view/forgot-password db params))
 
-  (GET "/password-resets/:reset-code" [reset-code]
-       (view/edit-password-form reset-code))
+   (GET "/password-resets/:reset-code" [reset-code]
+        (view/edit-password-form db reset-code))
 
-  (POST "/password-resets/:reset-code" {{:keys [reset-code password confirm]} :params}
-        (view/edit-password reset-code {:password password :confirm confirm}))
+   (POST "/password-resets/:reset-code" {{:keys [reset-code password confirm]} :params}
+         (view/edit-password db reset-code {:password password :confirm confirm}))
 
-  (GET "/users/:username" [username]
-       (show username))
-  (GET "/:username" [username]
-       (show username)))
+   (GET "/users/:username" [username]
+        (show db username))
+   (GET "/:username" [username]
+        (show db username))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -1,83 +1,90 @@
 (ns clojars.web
-  (:require [clojars.db :as db]
-            [clojars.config :refer [config]]
-            [clojars.auth :refer [try-account]]
-            [clojars.errors :refer [wrap-exceptions]]
+  (:require [cemerick.friend :as friend]
+            [cemerick.friend
+             [credentials :as creds]
+             [workflows :as workflows]]
+            [clojars
+             [auth :refer [try-account]]
+             [config :refer [config]]
+             [db :as db]
+             [errors :refer [wrap-exceptions]]]
             [clojars.friend.registration :as registration]
-            [clojars.web.dashboard :refer [dashboard index-page]]
-            [clojars.web.search :refer [search]]
-            [clojars.web.browse :refer [browse]]
-            [clojars.web.common :refer [html-doc]]
-            [clojars.web.safe-hiccup :refer [raw]]
+            [clojars.routes
+             [api :as api]
+             [artifact :as artifact]
+             [group :as group]
+             [repo :as repo]
+             [session :as session]
+             [user :as user]]
+            [clojars.web
+             [browse :refer [browse]]
+             [common :refer [html-doc]]
+             [dashboard :refer [dashboard index-page]]
+             [safe-hiccup :refer [raw]]
+             [search :refer [search]]]
             [clojure.java.io :as io]
-            [ring.middleware.anti-forgery :refer [wrap-anti-forgery]]
-            [ring.middleware.file-info :refer [wrap-file-info]]
-            [ring.middleware.flash :refer [wrap-flash]]
-            [ring.middleware.multipart-params :refer [wrap-multipart-params]]
-            [ring.middleware.params :refer [wrap-params]]
-            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
-            [ring.middleware.resource :refer [wrap-resource]]
-            [ring.middleware.session :refer [wrap-session]]
-            [compojure.core :refer [defroutes GET POST PUT ANY context routes]]
-            [compojure.route :refer [not-found]]
-            [cemerick.friend :as friend]
-            [cemerick.friend.credentials :as creds]
-            [cemerick.friend.workflows :as workflows]
-            [clojars.routes.session :as session]
-            [clojars.routes.user :as user]
-            [clojars.routes.artifact :as artifact]
-            [clojars.routes.group :as group]
-            [clojars.routes.repo :as repo]
-            [clojars.routes.api :as api]))
+            [compojure
+             [core :refer [ANY context GET PUT routes]]
+             [route :refer [not-found]]]
+            [ring.middleware
+             [anti-forgery :refer [wrap-anti-forgery]]
+             [file-info :refer [wrap-file-info]]
+             [flash :refer [wrap-flash]]
+             [keyword-params :refer [wrap-keyword-params]]
+             [multipart-params :refer [wrap-multipart-params]]
+             [params :refer [wrap-params]]
+             [resource :refer [wrap-resource]]
+             [session :refer [wrap-session]]]))
 
-(defroutes main-routes
-  (GET "/" _
-       (try-account
-        (if account
-          (dashboard account)
-          (index-page account))))
-  (GET "/search" {:keys [params]}
-       (try-account
-        (let [validated-params (if (:page params)
-                                 (assoc params :page (Integer. (:page params)))
-                                 params)]
-          (search account validated-params))))
-  (GET "/projects" {:keys [params]}
-       (try-account
-        (browse account params)))
-  (GET "/security" []
-       (try-account
-        (html-doc account "Security"
-                  (raw (slurp (io/resource "security.html"))))))
-  session/routes
-  group/routes
-  artifact/routes
-  ;; user routes must go after artifact routes
-  ;; since they both catch /:identifier
-  user/routes
-  api/routes
-  (GET "/error" _ (throw (Exception. "What!? You really want an error?")))
-  (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
-  (ANY "*" _
-       (try-account
-        (not-found
-         (html-doc account
-                   "Page not found"
-                   [:div.small-section
-                    [:h1 "Page not found"]
-                    [:p "Thundering typhoons!  I think we lost it.  Sorry!"]])))))
+(defn main-routes [db]
+  (routes
+   (GET "/" _
+        (try-account
+         (if account
+           (dashboard db account)
+           (index-page db account))))
+   (GET "/search" {:keys [params]}
+        (try-account
+         (let [validated-params (if (:page params)
+                                  (assoc params :page (Integer. (:page params)))
+                                  params)]
+           (search account validated-params))))
+   (GET "/projects" {:keys [params]}
+        (try-account
+         (browse db account params)))
+   (GET "/security" []
+        (try-account
+         (html-doc account "Security"
+                   (raw (slurp (io/resource "security.html"))))))
+   session/routes
+   (group/routes db)
+   (artifact/routes db)
+   ;; user routes must go after artifact routes
+   ;; since they both catch /:identifier
+   (user/routes db)
+   (api/routes db)
+   (GET "/error" _ (throw (Exception. "What!? You really want an error?")))
+   (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
+   (ANY "*" _
+        (try-account
+         (not-found
+          (html-doc account
+                    "Page not found"
+                    [:div.small-section
+                     [:h1 "Page not found"]
+                     [:p "Thundering typhoons!  I think we lost it.  Sorry!"]]))))))
 
 (defn bad-attempt [attempts user]
   (let [failures (or (attempts user) 0)]
     (Thread/sleep (* failures failures)))
   (update-in attempts [user] (fnil inc 0)))
 
-(def credential-fn
+(defn credential-fn [db]
   (let [attempts (atom {})]
     (partial creds/bcrypt-credential-fn
              (fn [id]
                (if-let [{:keys [user password]}
-                        (db/find-user-by-user-or-email id)]
+                        (db/find-user-by-user-or-email db id)]
                  (when-not (empty? password)
                    (swap! attempts dissoc user)
                    {:username user :password password})
@@ -99,29 +106,30 @@
         (secure-session req)
         (regular-session req)))))
 
-(defroutes clojars-app
-  (context "/repo" _
-           (-> repo/routes
-               (friend/authenticate
-                {:credential-fn credential-fn
-                 :workflows [(workflows/http-basic :realm "clojars")]
-                 :allow-anon? false
-                 :unauthenticated-handler
-                 (partial workflows/http-basic-deny "clojars")})
-               (repo/wrap-file (:repo config))
-               (repo/wrap-reject-double-dot)))
-  (-> main-routes
-      (friend/authenticate
-       {:credential-fn credential-fn
-        :workflows [(workflows/interactive-form)
-                    registration/workflow]})
-      (wrap-anti-forgery)
-      (wrap-x-frame-options)
-      (wrap-keyword-params)
-      (wrap-params)
-      (wrap-multipart-params)
-      (wrap-flash)
-      (wrap-secure-session)
-      (wrap-resource "public")
-      (wrap-file-info)
-      (wrap-exceptions)))
+(defn clojars-app [db]
+  (routes
+   (context "/repo" _
+            (-> (repo/routes db)
+                (friend/authenticate
+                 {:credential-fn (credential-fn db)
+                  :workflows [(workflows/http-basic :realm "clojars")]
+                  :allow-anon? false
+                  :unauthenticated-handler
+                  (partial workflows/http-basic-deny "clojars")})
+                (repo/wrap-file (:repo config))
+                (repo/wrap-reject-double-dot)))
+   (-> (main-routes db)
+       (friend/authenticate
+        {:credential-fn (credential-fn db)
+         :workflows [(workflows/interactive-form)
+                     (registration/workflow db)]})
+       (wrap-anti-forgery)
+       (wrap-x-frame-options)
+       (wrap-keyword-params)
+       (wrap-params)
+       (wrap-multipart-params)
+       (wrap-flash)
+       (wrap-secure-session)
+       (wrap-resource "public")
+       (wrap-file-info)
+       wrap-exceptions)))

--- a/src/clojars/web/browse.clj
+++ b/src/clojars/web/browse.clj
@@ -7,10 +7,10 @@
             [hiccup.form :refer [label submit-button text-field submit-button]]
             [ring.util.response :refer [redirect]]))
 
-(defn browse-page [account page per-page]
-  (let [project-count (count-all-projects)
+(defn browse-page [db account page per-page]
+  (let [project-count (count-all-projects db)
         total-pages (-> (/ project-count per-page) Math/ceil .intValue)
-        projects (browse-projects page per-page)]
+        projects (browse-projects db page per-page)]
     (html-doc account "All projects"
      [:div.light-article.row
       [:h1 "All projects"]
@@ -41,10 +41,10 @@
               [:td (format-date created)])]]])]
       (page-nav page total-pages)])))
 
-(defn browse [account params]
+(defn browse [db account params]
   (let [per-page 20]
     (if-let [from (:from params)]
-      (let [i (count-projects-before from)
+      (let [i (count-projects-before db from)
             page (inc (int (/ i per-page)))]
         (redirect (str "/projects?page=" page "#" (mod i per-page))))
-      (browse-page account (Integer. (or (:page params) 1)) per-page))))
+      (browse-page db account (Integer. (or (:page params) 1)) per-page))))

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -20,7 +20,7 @@
                                                                    (:group_name jar-map)
                                                                    (:jar_name jar-map))]]]))
 
-(defn index-page [account]
+(defn index-page [db account]
   (html-doc-with-large-header account nil
     [:article.row
      [:div.push-information.col-md-6.col-lg-6.col-sm-6.col-xs-12
@@ -39,24 +39,25 @@
     [:div.recent-jars-header-container.row
      [:h2.recent-jars-header.col-md-12.col-lg-12.col-sm-12.col-xs-12
       "Recently pushed projects"]]
-    [:ul.recent-jars-list.row (map recent-jar (recent-jars))]))
+    [:ul.recent-jars-list.row (map recent-jar (recent-jars db))]))
 
-(defn dashboard [account]
+(defn dashboard [db account]
   (html-doc account "Dashboard"
     [:div.light-article.col-md-12.col-lg-12.col-xs-12.col-sm-12
      [:h1 (str "Dashboard (" account ")")]
      [:div.col-md-4.col-lg-4.col-sm-4.col-xs-12
       [:div.dash-palette
        [:h2 "Your Projects"]
-       (if (seq (jars-by-username account))
-         (unordered-list (map jar-link (jars-by-username account)))
-         [:p "You don't have any projects, would you like to "
-          (link-to "http://wiki.github.com/ato/clojars-web/pushing" "add one")
-          "?"])]]
+       (let [jars (jars-by-username db account)]
+         (if (seq jars)
+           (unordered-list (map jar-link jars))
+           [:p "You don't have any projects, would you like to "
+            (link-to "http://wiki.github.com/ato/clojars-web/pushing" "add one")
+            "?"]))]]
      [:div.col-md-4.col-lg-4.col-sm-4.col-xs-12
       [:div.dash-palette
        [:h2 "Your Groups"]
-       (unordered-list (map group-link (find-groupnames account)))]]
+       (unordered-list (map group-link (find-groupnames db account)))]]
      [:div.col-md-4.col-lg-4.col-sm-4.col-xs-12
       [:div.dash-palette
        [:h2 "FAQ"]

--- a/src/clojars/web/group.clj
+++ b/src/clojars/web/group.clj
@@ -6,16 +6,16 @@
             [hiccup.form :refer [text-field submit-button]]
             [clojars.web.safe-hiccup :refer [form-to]]))
 
-(defn show-group [account groupname membernames & errors]
+(defn show-group [db account groupname membernames & errors]
   (html-doc account (str groupname " group")
     [:div.small-section.col-md-6.col-lg-6.col-sm-6.col-xs-12
      [:h1 (str groupname " group")]
      [:h2 "Projects"]
-     (unordered-list (map jar-link (jars-by-groupname groupname)))
+     (unordered-list (map jar-link (jars-by-groupname db groupname)))
      [:h2 "Members"]
      (unordered-list (map user-link (sort membernames)))
      (error-list errors)
-     (when (authorized? account groupname)
+     (when (authorized? db account groupname)
        [:div.add-member
         (form-to [:post (str "/groups/" groupname)]
                  (text-field "username")

--- a/test/clojars/test/integration/api.clj
+++ b/test/clojars/test/integration/api.clj
@@ -9,8 +9,10 @@
             [clojure.string :as string]
             [cheshire.core :as json]))
 
-(use-fixtures :once help/run-test-app #_(partial help/run-test-app :verbose))
-(use-fixtures :each help/default-fixture)
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database
+  help/run-test-app)
 
 (defn get-api [parts & [opts]]
   (-> (str "http://localhost:" help/test-port "/api/"
@@ -34,12 +36,12 @@
   (is (= (get-content-type {:headers {"content-type" "application/json;charset=utf-8"}}) "application/json")))
 
 (deftest an-api-test
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "dantheman" "test@example.org" "password"))
-  (inject-artifacts-into-repo! "dantheman" "test.jar" "test-0.0.1/test.pom")
-  (inject-artifacts-into-repo! "dantheman" "test.jar" "test-0.0.2/test.pom")
-  (inject-artifacts-into-repo! "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (inject-artifacts-into-repo! "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (inject-artifacts-into-repo! help/*db* "dantheman" "test.jar" "test-0.0.1/test.pom")
+  (inject-artifacts-into-repo! help/*db* "dantheman" "test.jar" "test-0.0.2/test.pom")
+  (inject-artifacts-into-repo! help/*db* "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (inject-artifacts-into-repo! help/*db* "dantheman" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
 
   (doseq [f ["application/json" "application/edn" "application/x-yaml" "application/transit+json"]]
     (testing f

--- a/test/clojars/test/integration/jars.clj
+++ b/test/clojars/test/integration/jars.clj
@@ -7,14 +7,16 @@
             [clojars.test.test-helper :as help]
             [net.cgrand.enlive-html :as html]))
 
-(use-fixtures :each help/default-fixture)
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database)
 
 (deftest jars-can-be-viewed
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.1/test.pom")
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.2/test.pom")
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (session web/clojars-app)
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.1/test.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.2/test.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (-> (session (web/clojars-app help/*db*))
       (visit "/fake/test")
       (within [:div#jar-title :h1 :a]
               (has (text? "fake/test")))
@@ -24,8 +26,8 @@
               (has (text? "0.0.3-SNAPSHOT0.0.20.0.1")))))
 
 (deftest jars-with-only-snapshots-can-be-viewed
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (session web/clojars-app)
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (-> (session (web/clojars-app help/*db*))
       (visit "/fake/test")
       (within [:div#jar-title :h1 :a]
               (has (text? "fake/test")))
@@ -37,10 +39,10 @@
               (has (text? "0.0.3-SNAPSHOT")))))
 
 (deftest canonical-jars-can-be-viewed
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.1/fake.pom")
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.2/fake.pom")
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.3-SNAPSHOT/fake.pom")
-  (-> (session web/clojars-app)
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.1/fake.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.2/fake.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.3-SNAPSHOT/fake.pom")
+  (-> (session (web/clojars-app help/*db*))
       (visit "/fake")
       (within [:div#jar-title :h1 :a]
               (has (text? "fake")))
@@ -50,10 +52,10 @@
               (has (text? "0.0.3-SNAPSHOT0.0.20.0.1")))))
 
 (deftest specific-versions-can-be-viewed
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.1/test.pom")
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.2/test.pom")
-  (inject-artifacts-into-repo! "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (session web/clojars-app)
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.1/test.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.2/test.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
+  (-> (session (web/clojars-app help/*db*))
       (visit "/fake/test")
       (follow "0.0.3-SNAPSHOT")
       (within [:div#jar-title :h1 :a]
@@ -64,10 +66,10 @@
               (has (text? "0.0.3-SNAPSHOT0.0.20.0.1")))))
 
 (deftest specific-canonical-versions-can-be-viewed
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.1/fake.pom")
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.2/fake.pom")
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.3-SNAPSHOT/fake.pom")
-  (-> (session web/clojars-app)
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.1/fake.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.2/fake.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.3-SNAPSHOT/fake.pom")
+  (-> (session (web/clojars-app help/*db*))
       (visit "/fake")
       (follow "0.0.1")
       (within [:div#jar-title :h1 :a]
@@ -79,9 +81,9 @@
 
 
 (deftest canonical-jars-can-view-dependencies
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.1/fake.pom")
-  (inject-artifacts-into-repo! "someuser" "fake.jar" "fake-0.0.2/fake.pom")
-  (-> (session web/clojars-app)
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.1/fake.pom")
+  (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.2/fake.pom")
+  (-> (session (web/clojars-app help/*db*))
       (visit "/fake")
       (within [:ul#dependencies]
                (has (text? "org.clojure/clojure 1.3.0-beta1")))))

--- a/test/clojars/test/integration/responses.clj
+++ b/test/clojars/test/integration/responses.clj
@@ -7,23 +7,25 @@
             [clojars.test.test-helper :as help]
             [net.cgrand.enlive-html :as enlive]))
 
-(use-fixtures :each help/default-fixture)
+(use-fixtures :each
+  help/using-test-config
+  help/with-clean-database)
 
 (deftest respond-404
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (visit "/nonexistent-route")
       (has (status? 404))
       (within [:title]
               (has (text? "Page not found - Clojars")))))
 
 (deftest respond-404-for-non-existent-group
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (visit "/groups/nonexistent.group")
       (has (status? 404))
       (within [:title]
               (has (text? "Page not found - Clojars")))))
 
 (deftest respond-405-for-puts
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (visit "/nonexistent-route" :request-method :put)
       (has (status? 405))))

--- a/test/clojars/test/integration/sessions.clj
+++ b/test/clojars/test/integration/sessions.clj
@@ -1,13 +1,16 @@
 (ns clojars.test.integration.sessions
-  (:require [clojure.test :refer :all]
-            [kerodon.core :refer :all]
-            [kerodon.test :refer :all]
+  (:require [clojars.config :as config]
+            [clojars.db :as db]
             [clojars.test.integration.steps :refer :all]
             [clojars.db :as db]
             [clojars.web :as web]
             [clojars.test.test-helper :as help]
-            [net.cgrand.enlive-html :as enlive]
-            [korma.core :as korma]))
+            [clojure.test :refer :all]
+            [kerodon
+             [core :refer :all]
+             [test :refer :all]]
+            [clojure.java.jdbc :as jdbc]
+            [net.cgrand.enlive-html :as enlive]))
 
 (use-fixtures :each help/default-fixture)
 
@@ -38,9 +41,8 @@
 (deftest user-with-password-wipe-gets-message
   (-> (session web/clojars-app)
       (register-as "fixture" "fixture@example.org" "password"))
-  (korma/update db/users
-                (korma/set-fields {:password ""})
-                (korma/where {:user "fixture"}))
+  (jdbc/db-do-commands (:db config/config)
+                       "update users set password='' where user = 'fixture'")
   (-> (session web/clojars-app)
       (login-as "fixture" "password")
       (follow-redirect)

--- a/test/clojars/test/integration/steps.clj
+++ b/test/clojars/test/integration/steps.clj
@@ -1,10 +1,9 @@
 (ns clojars.test.integration.steps
   (:require [cemerick.pomegranate.aether :as aether]
-            [clojars.config :as config]
             [clojars.db :as db]
             [clojars.maven :as maven]
+            [clojars.test.test-helper :as help]
             [clojure.java.io :as io]
-            [clojure.test :as test]
             [kerodon.core :refer :all]
             [clojars.config :refer [config]])
   (:import java.io.File))
@@ -33,13 +32,14 @@
 (defn file-repo [path]
   (str (.toURI (File. path))))
 
-(defn inject-artifacts-into-repo! [user jar pom]
+(defn inject-artifacts-into-repo! [db user jar pom]
   (let [pom-file (io/resource pom)
         jarmap (maven/pom-to-map pom-file)]
-    (db/add-jar user jarmap)
+    (db/add-jar db user jarmap)
     (aether/deploy :coordinates [(keyword (:group jarmap)
                                           (:name jarmap))
                                  (:version jarmap)]
                    :jar-file (io/resource jar)
                    :pom-file pom-file
+                   :local-repo help/local-repo
                    :repository {"local" (file-repo (:repo config))})))

--- a/test/clojars/test/integration/uploads.clj
+++ b/test/clojars/test/integration/uploads.clj
@@ -1,15 +1,17 @@
 (ns clojars.test.integration.uploads
-  (:require [clojure.test :refer :all]
-            [kerodon.core :refer :all]
-            [kerodon.test :refer :all]
-            [clojars.config :refer [config]]
-            [clojars.web :refer [clojars-app]]
+  (:require [cemerick.pomegranate.aether :as aether]
+            [clojars
+             [config :refer [config]]
+             [web :as web :refer [clojars-app]]]
             [clojars.test.integration.steps :refer :all]
             [clojars.test.test-helper :as help]
+            [clojure.data.codec.base64 :as base64]
             [clojure.java.io :as io]
-            [cemerick.pomegranate.aether :as aether]
-            [net.cgrand.enlive-html :as enlive]
-            [clojure.data.codec.base64 :as base64]))
+            [clojure.test :refer :all]
+            [kerodon
+             [core :refer :all]
+             [test :refer :all]]
+            [net.cgrand.enlive-html :as enlive]))
 
 (use-fixtures :once help/run-test-app)
 (use-fixtures :each help/default-fixture help/index-fixture)
@@ -51,7 +53,15 @@
       (follow "org.clojars.dantheman/test")
       (has (status? 200))
       (within [:#jar-sidebar :li.homepage :a]
-              (has (text? "https://example.org")))))
+              (has (text? "https://example.org"))))
+  (-> (session clojars-app)
+      (visit "/")
+      (fill-in [:#search] "test")
+      (press [:#search-button])
+      ;; the pom is used as is, even if the data is wrong
+      ;; https://github.com/ato/clojars-web/issues/358
+      (within [:div.result]
+              (has (text? "fake/test 0.0.1")))))
 
 (deftest user-can-deploy-to-new-group
    (-> (session clojars-app)
@@ -283,7 +293,9 @@
         (visit "/repo/group3/artifact3/1.0.0/test.jar"
                :body (proxy [java.io.InputStream] []
                        (read
-                         ([_] (throw (java.io.IOException.)))))
+                         ([] (throw (java.io.IOException.)))
+                         ([^bytes bytes] (throw (java.io.IOException.)))
+                         ([^bytes bytes off len] (throw (java.io.IOException.)))))
                :request-method :put
                :content-length 1000
                :content-type "txt/plain"

--- a/test/clojars/test/integration/users.clj
+++ b/test/clojars/test/integration/users.clj
@@ -7,10 +7,12 @@
             [clojars.test.test-helper :as help]
             [net.cgrand.enlive-html :as enlive]))
 
-(use-fixtures :each help/default-fixture)
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database)
 
 (deftest user-can-register
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "dantheman" "test@example.org" "password")
       (follow-redirect)
       (has (status? 200))
@@ -18,9 +20,9 @@
               (has (text? "Dashboard (dantheman)")))))
 
 (deftest bad-registration-info-should-show-error
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "fixture" "fixture@example.org" "password"))
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (visit "/")
       (follow "register")
       (has (status? 200))
@@ -76,7 +78,7 @@
               (has (text? "Username is already taken")))))
 
 (deftest user-can-update-info
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "fixture" "fixture@example.org" "password")
       (follow-redirect)
       (follow "profile")
@@ -99,7 +101,7 @@
               (has (text? "Dashboard (fixture)")))))
 
 (deftest bad-update-info-should-show-error
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "fixture" "fixture@example.org" "password")
       (follow-redirect)
       (follow "profile")
@@ -122,9 +124,9 @@
 (deftest user-can-get-new-password
   (let [transport (promise)]
     (with-redefs [clojars.email/send-out (fn [x] (deliver transport x))]
-      (-> (session web/clojars-app)
+      (-> (session (web/clojars-app help/*db*))
           (register-as "fixture" "fixture@example.org" "password"))
-      (-> (session web/clojars-app)
+      (-> (session (web/clojars-app help/*db*))
           (visit "/")
           (follow "login")
           (follow "Forgot password?")
@@ -150,7 +152,7 @@
                 #"Hello,\n\nWe received a request from someone, hopefully you, to reset the password of your clojars user.\n\nTo contine with the reset password process, click on the following link:\n\n([^ ]+)"
                 (.getContent (.getMimeMessage email)))]
           (is (seq reset-password-link))
-          (-> (session web/clojars-app)
+          (-> (session (web/clojars-app help/*db*))
               (visit reset-password-link)
               (has (status? 200))
               (fill-in "New password" password)
@@ -169,16 +171,16 @@
                       (has (text? "Dashboard (fixture)")))))))))
 
 (deftest bad-reset-code-shows-message
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (visit "/password-resets/this-code-does-not-exist")
       (has (status? 200))
       (within [:p]
         (has (text? "The reset code was not found. Please ask for a new code in the forgot password page")))))
 
 (deftest member-can-add-user-to-group
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "fixture" "fixture@example.org" "password"))
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "fixture")
@@ -188,7 +190,7 @@
               (has (text? "danthemanfixture")))))
 
 (deftest user-must-exist-to-be-added-to-group
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "fixture")
@@ -197,7 +199,7 @@
               (has (text? "No such user: fixture")))))
 
 (deftest users-can-be-viewed
-  (-> (session web/clojars-app)
+  (-> (session (web/clojars-app help/*db*))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/users/dantheman")
       (within [:div.light-article :> :h1]

--- a/test/clojars/test/test_helper.clj
+++ b/test/clojars/test/test_helper.clj
@@ -5,14 +5,11 @@
             [clojars.config :refer [config]]
             [clojars.web :as web]
             [clojars.main :as main]
-            [korma.db :as kdb]
             [clucy.core :as clucy]
-            [clojars.search :as search]
-            [clojure.test :as test]
             [clojure.java.shell :as sh]
-            [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
-            [ring.adapter.jetty :as jetty]))
+            [clojure.java.io :as io]
+            [clojars.search :as search]))
 
 (def local-repo (io/file (System/getProperty "java.io.tmpdir")
                          "clojars" "test" "local-repo"))
@@ -77,11 +74,9 @@
      (delete-file-recursively (io/file (config :stats-dir)))
      (.mkdirs (io/file (config :stats-dir)))
      (make-download-count! {})
-     (with-redefs [kdb/_default (atom {:pool (:db config)})]
-       (jdbc/with-connection (:pool @kdb/_default)
-         (jdbc/do-commands
-          "delete from users;" "delete from jars;" "delete from groups;"))
-       (f)))))
+     (jdbc/db-do-commands (:db config)
+                          "delete from users;" "delete from jars;" "delete from groups;")
+     (f))))
 
 (defn index-fixture [f]
   (make-index! [])

--- a/test/clojars/test/unit/db.clj
+++ b/test/clojars/test/unit/db.clj
@@ -5,7 +5,9 @@
             [clj-time.core :as time]
             [clojure.test :refer :all]))
 
-(use-fixtures :each help/default-fixture help/index-fixture)
+(use-fixtures :each
+  help/using-test-config
+  help/with-clean-database)
 
 (defn submap [s m]
   (every? (fn [[k v]] (= (m k) v)) s))
@@ -14,33 +16,32 @@
   (let [email "test@example.com"
         name "testuser"
         password "password"
-        pgp-key "aoeu"
-        ms (long 0)]
-      (is (db/add-user email name password pgp-key))
+        pgp-key "aoeu"]
+      (is (db/add-user help/*db* email name password pgp-key))
       (are [x] (submap {:email email
                         :user name}
                        x)
-           (db/find-user name)
-           (db/find-user-by-user-or-email name)
-           (db/find-user-by-user-or-email email))))
+           (db/find-user help/*db* name)
+           (db/find-user-by-user-or-email help/*db* name)
+           (db/find-user-by-user-or-email help/*db* email))))
 
 (deftest user-does-not-exist
-  (is (not (db/find-user-by-user-or-email "test2@example.com"))))
+  (is (not (db/find-user-by-user-or-email help/*db* "test2@example.com"))))
 
 (deftest added-users-can-be-found-by-password-reset-code-except-when-expired
   (let [email "test@example.com"
         name "testuser"
         password "password"
         pgp-key "aoeu"]
-      (db/add-user email name password pgp-key)
-      (let [reset-code (db/set-password-reset-code! "test@example.com")]
+      (db/add-user help/*db* email name password pgp-key)
+      (let [reset-code (db/set-password-reset-code! help/*db* "test@example.com")]
         (is (submap {:email email
                      :user name
                      :password_reset_code reset-code}
-                    (db/find-user-by-password-reset-code reset-code)))
+                    (db/find-user-by-password-reset-code help/*db* reset-code)))
 
         (time/do-at (-> 1 time/days time/from-now)
-          (is (not (db/find-user-by-password-reset-code reset-code)))))))
+          (is (not (db/find-user-by-password-reset-code help/*db* reset-code)))))))
 
 (deftest updated-users-can-be-found
   (let [email "test@example.com"
@@ -53,39 +54,39 @@
         password2 "password2"
         pgp-key2 "aoeu2"]
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. ms))]
-      (is (db/add-user email name password pgp-key))
+      (is (db/add-user help/*db* email name password pgp-key))
       (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 1)))]
-        (is (db/update-user name email2 name2 password2 pgp-key2))
+        (is (db/update-user help/*db* name email2 name2 password2 pgp-key2))
         (are [x] (submap {:email email2
                           :user name2
                           :pgp_key pgp-key2
                           :created ms}
                          x)
-             (db/find-user name2)
-             (db/find-user-by-user-or-email name2)
-             (db/find-user-by-user-or-email email2)))
-      (is (not (db/find-user name))))))
+             (db/find-user help/*db* name2)
+             (db/find-user-by-user-or-email help/*db* name2)
+             (db/find-user-by-user-or-email help/*db* email2)))
+      (is (not (db/find-user help/*db* name))))))
 
 (deftest added-users-are-added-only-to-their-org-clojars-group
   (let [email "test@example.com"
         name "testuser"
         password "password"
         pgp-key "aoeu"]
-    (is (db/add-user email name password pgp-key))
+    (is (db/add-user help/*db* email name password pgp-key))
     (is (= ["testuser"]
-           (db/group-membernames (str "org.clojars." name))))
+           (db/group-membernames help/*db* (str "org.clojars." name))))
     (is (= ["org.clojars.testuser"]
-           (db/find-groupnames name)))))
+           (db/find-groupnames help/*db* name)))))
 
 (deftest users-can-be-added-to-groups
   (let [email "test@example.com"
         name "testuser"
         password "password"
         pgp-key "aoeu"]
-    (db/add-user email name password pgp-key)
-    (db/add-member "test-group" name "some-dude")
-    (is (= ["testuser"] (db/group-membernames "test-group")))
-    (is (some #{"test-group"} (db/find-groupnames name)))))
+    (db/add-user help/*db* email name password pgp-key)
+    (db/add-member help/*db* "test-group" name "some-dude")
+    (is (= ["testuser"] (db/group-membernames help/*db* "test-group")))
+    (is (some #{"test-group"} (db/find-groupnames help/*db* name)))))
 
 ;;TODO: Tests below should have the users added first.
 ;;Currently user unenforced foreign keys are by name
@@ -108,11 +109,11 @@
                 :authors "Alex Osborne, a little fish"
                 :description "An dog awesome and non-existent test jar."}]
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. ms))]
-      (is (db/add-jar "test-user" jarmap))
+      (is (db/add-jar help/*db* "test-user" jarmap))
       (are [x] (submap result x)
-           (db/find-jar name name)
-           (first (db/jars-by-groupname name))
-           (first (db/jars-by-username "test-user"))))))
+           (db/find-jar help/*db* name name)
+            (first (db/jars-by-groupname help/*db* name))
+           (first (db/jars-by-username help/*db* "test-user"))))))
 
 (deftest jars-can-be-deleted-by-group
   (let [group "foo"
@@ -120,17 +121,17 @@
              :description "An dog awesome and non-existent test jar."
              :homepage "http://clojars.org/"
              :authors ["Alex Osborne" "a little fish"]}]
-    (db/add-jar "test-user" jar)
-    (db/add-jar "test-user"
+    (db/add-jar help/*db* "test-user" jar)
+    (db/add-jar help/*db* "test-user"
       (assoc jar
         :name "two"))
-    (db/add-jar "test-user"
+    (db/add-jar help/*db* "test-user"
       (assoc jar
         :group "another"))
-    (is (= 2 (count (db/jars-by-groupname group))))
-    (db/delete-jars group)
-    (is (empty? (db/jars-by-groupname group)))
-    (is (= 1 (count (db/jars-by-groupname "another"))))))
+    (is (= 2 (count (db/jars-by-groupname help/*db* group))))
+    (db/delete-jars help/*db* group)
+    (is (empty? (db/jars-by-groupname help/*db* group)))
+    (is (= 1 (count (db/jars-by-groupname help/*db* "another"))))))
 
 (deftest jars-can-be-deleted-by-group-and-jar-id
   (let [group "foo"
@@ -138,13 +139,13 @@
              :description "An dog awesome and non-existent test jar."
              :homepage "http://clojars.org/"
              :authors ["Alex Osborne" "a little fish"]}]
-    (db/add-jar "test-user" jar)
-    (db/add-jar "test-user"
+    (db/add-jar help/*db* "test-user" jar)
+    (db/add-jar help/*db* "test-user"
       (assoc jar
         :name "two"))
-    (is (= 2 (count (db/jars-by-groupname group))))
-    (db/delete-jars group "one")
-    (is (= 1 (count (db/jars-by-groupname group))))))
+    (is (= 2 (count (db/jars-by-groupname help/*db* group))))
+    (db/delete-jars help/*db* group "one")
+    (is (= 1 (count (db/jars-by-groupname help/*db* group))))))
 
 (deftest jars-can-be-deleted-by-group-and-jar-id-and-version
   (let [group "foo"
@@ -152,15 +153,18 @@
              :description "An dog awesome and non-existent test jar."
              :homepage "http://clojars.org/"
              :authors ["Alex Osborne" "a little fish"]}]
-    (db/add-jar "test-user" jar)
-    (db/jars-by-groupname group)
-    (db/add-jar "test-user"
-      (assoc jar
-        :version "2.0"))
-    (db/jars-by-groupname group)
-    (is (= "2.0" (-> (db/jars-by-groupname group) first :version)))
-    (db/delete-jars group "one" "2.0")
-    (is (= "1.0" (-> (db/jars-by-groupname group) first :version)))))
+
+    (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 0)))]
+                 (db/add-jar help/*db* "test-user" jar))
+    (db/jars-by-groupname help/*db* group)
+    (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 1)))]
+                (db/add-jar help/*db* "test-user"
+                            (assoc jar
+                                   :version "2.0")))
+    (db/jars-by-groupname help/*db* group)
+    (is (= "2.0" (-> (db/jars-by-groupname help/*db* group) first :version)))
+    (db/delete-jars help/*db* group "one" "2.0")
+    (is (= "1.0" (-> (db/jars-by-groupname help/*db* group) first :version)))))
 
 (deftest jars-by-group-only-returns-most-recent-version
   (let [name "tester"
@@ -170,10 +174,10 @@
                 :user "test-user"
                 :group_name name }]
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 0))]
-      (is (db/add-jar "test-user" jarmap))
+      (is (db/add-jar help/*db* "test-user" jarmap))
       (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 1))]
-        (is (db/add-jar "test-user" (assoc jarmap :version "2")))))
-    (let [jars (db/jars-by-groupname name)]
+        (is (db/add-jar help/*db* "test-user" (assoc jarmap :version "2")))))
+    (let [jars (db/jars-by-groupname help/*db* name)]
       (dorun (map #(is (= %1 (select-keys %2 (keys %1)))) [result] jars))
       (is (= 1 (count jars))))))
 
@@ -181,19 +185,19 @@
   (let [name "tester"
         jarmap {:name name :group name :version "1" }]
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 0))]
-      (is (db/add-jar "test-user" jarmap)))
+      (is (db/add-jar help/*db* "test-user" jarmap)))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 1))]
-      (is (db/add-jar "test-user" (assoc jarmap :version "2"))))
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :version "2"))))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 2))]
-      (is (db/add-jar "test-user" (assoc jarmap :version "3"))))
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :version "3"))))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 3))]
-      (is (db/add-jar "test-user" (assoc jarmap :version "4-SNAPSHOT"))))
-    (is (= 4 (db/count-versions name name)))
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :version "4-SNAPSHOT"))))
+    (is (= 4 (db/count-versions help/*db* name name)))
     (is (= ["4-SNAPSHOT" "3" "2" "1"]
-           (map :version (db/recent-versions name name))))
-    (is (= ["4-SNAPSHOT"] (map :version (db/recent-versions name name 1))))
-    (is (= "3" (:version (db/find-jar name name))))
-    (is (= "4-SNAPSHOT" (:version (db/find-jar name name "4-SNAPSHOT"))))))
+           (map :version (db/recent-versions help/*db* name name))))
+    (is (= ["4-SNAPSHOT"] (map :version (db/recent-versions help/*db* name name 1))))
+    (is (= "3" (:version (db/find-jar help/*db* name name))))
+    (is (= "4-SNAPSHOT" (:version (db/find-jar help/*db* name name "4-SNAPSHOT"))))))
 
 (deftest jars-by-group-returns-all-jars-in-group
   (let [name "tester"
@@ -201,18 +205,18 @@
         result {:jar_name name
                 :version "1"
                 :group_name name }]
-    (db/add-member name "test-user" "some-dude")
-    (db/add-member "tester-group" "test-user2" "some-dude")
-    (db/add-member name "test-user2" "some-dude")
+    (db/add-member help/*db* name "test-user" "some-dude")
+    (db/add-member help/*db* "tester-group" "test-user2" "some-dude")
+    (db/add-member help/*db* name "test-user2" "some-dude")
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 0))]
-      (is (db/add-jar "test-user" jarmap)))
+      (is (db/add-jar help/*db* "test-user" jarmap)))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 1))]
-      (is (db/add-jar "test-user" (assoc jarmap :name "tester2"))))
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :name "tester2"))))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 2))]
-      (is (db/add-jar "test-user2" (assoc jarmap :name "tester3"))))
+      (is (db/add-jar help/*db* "test-user2" (assoc jarmap :name "tester3"))))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 3))]
-      (is (db/add-jar "test-user2" (assoc jarmap :group "tester-group"))))
-    (let [jars (db/jars-by-groupname name)]
+      (is (db/add-jar help/*db* "test-user2" (assoc jarmap :group "tester-group"))))
+    (let [jars (db/jars-by-groupname help/*db* name)]
       (dorun (map #(is (submap %1 %2))
                   [result
                    (assoc result :jar_name "tester2")
@@ -228,10 +232,10 @@
                 :user "test-user"
                 :group_name name }]
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 0))]
-      (is (db/add-jar "test-user" jarmap)))
+      (is (db/add-jar help/*db* "test-user" jarmap)))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 1))]
-      (is (db/add-jar "test-user" (assoc jarmap :version "2"))))
-    (let [jars (db/jars-by-username "test-user")]
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :version "2"))))
+    (let [jars (db/jars-by-username help/*db* "test-user")]
       (dorun (map #(is (= %1 (select-keys %2 (keys %1)))) [result] jars))
       (is (= 1 (count jars))))))
 
@@ -242,18 +246,18 @@
                 :user "test-user"
                 :version "1"
                 :group_name name }]
-    (db/add-member name "test-user" "some-dude")
-    (db/add-member "tester-group" "test-user" "some-dude")
-    (db/add-member name "test-user2" "some-dude")
+    (db/add-member help/*db* name "test-user" "some-dude")
+    (db/add-member help/*db* "tester-group" "test-user" "some-dude")
+    (db/add-member help/*db* name "test-user2" "some-dude")
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 0))]
-      (is (db/add-jar "test-user" jarmap)))
+      (is (db/add-jar help/*db* "test-user" jarmap)))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 1))]
-      (is (db/add-jar "test-user" (assoc jarmap :name "tester2"))))
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :name "tester2"))))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 2))]
-      (is (db/add-jar "test-user2" (assoc jarmap :name "tester3"))))
+      (is (db/add-jar help/*db* "test-user2" (assoc jarmap :name "tester3"))))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. 3))]
-      (is (db/add-jar "test-user" (assoc jarmap :group "tester-group"))))
-    (let [jars (db/jars-by-username "test-user")]
+      (is (db/add-jar help/*db* "test-user" (assoc jarmap :group "tester-group"))))
+    (let [jars (db/jars-by-username help/*db* "test-user")]
       (dorun (map #(is (submap %1 %2))
                   [result
                    (assoc result :jar_name "tester2")
@@ -263,40 +267,40 @@
 
 (deftest add-jar-validates-group-name-format
   (let [jarmap {:name "jar-name" :version "1"}]
-    (is (thrown? Exception (db/add-jar "test-user" jarmap)))
-    (is (thrown? Exception (db/add-jar "test-user"
+    (is (thrown? Exception (db/add-jar help/*db* "test-user" jarmap)))
+    (is (thrown? Exception (db/add-jar help/*db* "test-user"
                                        (assoc jarmap :group "HI"))))
-    (is (thrown? Exception (db/add-jar "test-user"
+    (is (thrown? Exception (db/add-jar help/*db* "test-user"
                                        (assoc jarmap :group "lein*"))))
-    (is (thrown? Exception (db/add-jar "test-user"
+    (is (thrown? Exception (db/add-jar help/*db* "test-user"
                                        (assoc jarmap :group "lein="))))
-    (is (thrown? Exception (db/add-jar "test-user"
+    (is (thrown? Exception (db/add-jar help/*db* "test-user"
                                        (assoc jarmap :group "lein>"))))
-    (is (thrown? Exception (db/add-jar "test-user"
+    (is (thrown? Exception (db/add-jar help/*db* "test-user"
                                        (assoc jarmap :group "べ"))))
-    (is (db/add-jar "test-user" (assoc jarmap :group "hi")))
-    (is (db/add-jar "test-user" (assoc jarmap :group "hi-")))
-    (is (db/add-jar "test-user" (assoc jarmap :group "hi_1...2")))))
+    (is (db/add-jar help/*db* "test-user" (assoc jarmap :group "hi")))
+    (is (db/add-jar help/*db* "test-user" (assoc jarmap :group "hi-")))
+    (is (db/add-jar help/*db* "test-user" (assoc jarmap :group "hi_1...2")))))
 
 (deftest add-jar-validates-group-name-is-not-reserved
   (let [jarmap {:name "jar-name" :version "1"}]
     (doseq [group db/reserved-names]
-      (is (thrown? Exception (db/add-jar "test-user"
+      (is (thrown? Exception (db/add-jar help/*db* "test-user"
                                          (assoc jarmap :group group)))))))
 
 (deftest add-jar-validates-group-permissions
     (let [jarmap {:name "jar-name" :version "1" :group "group-name"}]
-      (db/add-member "group-name" "some-user" "some-dude")
-      (is (thrown? Exception (db/add-jar "test-user" jarmap)))))
+      (db/add-member help/*db* "group-name" "some-user" "some-dude")
+      (is (thrown? Exception (db/add-jar help/*db* "test-user" jarmap)))))
 
 
 (deftest add-jar-creates-single-member-group-for-user
     (let [jarmap {:name "jar-name" :version "1" :group "group-name"}]
-      (is (empty? (db/group-membernames "group-name")))
-      (db/add-jar "test-user" jarmap)
-      (is (= ["test-user"] (db/group-membernames "group-name")))
+      (is (empty? (db/group-membernames help/*db* "group-name")))
+      (db/add-jar help/*db* "test-user" jarmap)
+      (is (= ["test-user"] (db/group-membernames help/*db* "group-name")))
       (is (= ["group-name"]
-             (db/find-groupnames "test-user")))))
+             (db/find-groupnames help/*db* "test-user")))))
 
 (deftest recent-jars-returns-6-most-recent-jars-only-most-recent-version
   (let [name "tester"
@@ -315,39 +319,42 @@
                 :authors "Alex Osborne, a little fish"
                 :description "An dog awesome and non-existent test jar."}]
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 1)))]
-      (db/add-jar "test-user" (assoc jarmap :name "1")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :name "1")))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 2)))]
-      (db/add-jar "test-user" (assoc jarmap :name "2")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :name "2")))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 3)))]
-      (db/add-jar "test-user" (assoc jarmap :name "3")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :name "3")))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 4)))]
-      (db/add-jar "test-user" (assoc jarmap :name "4")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :name "4")))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 5)))]
-      (db/add-jar "test-user" (assoc jarmap :version "5")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :version "5")))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 6)))]
-      (db/add-jar "test-user" (assoc jarmap :name "6")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :name "6")))
     (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 7)))]
-      (db/add-jar "test-user" (assoc jarmap :version "7")))
+      (db/add-jar help/*db* "test-user" (assoc jarmap :version "7")))
     (dorun (map #(is (submap %1 %2))
                 [(assoc result :version "7")
                  (assoc result :jar_name "6")
                  (assoc result :jar_name "4")
                  (assoc result :jar_name "3")
                  (assoc result :jar_name "2")]
-                (db/recent-jars)))))
+                (db/recent-jars help/*db*)))))
 
 (deftest browse-projects-finds-jars
-  (db/add-jar "test-user" {:name "rock" :group "jester" :version "0.1"})
-  (db/add-jar "test-user" {:name "rock" :group "tester" :version "0.1"})
-  (db/add-jar "test-user" {:name "rock" :group "tester" :version "0.2"})
-  (db/add-jar "test-user" {:name "paper" :group "tester" :version "0.1"})
-  (db/add-jar "test-user" {:name "scissors" :group "tester" :version "0.1"})
+  (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 0)))]
+    (db/add-jar help/*db* "test-user" {:name "rock" :group "jester" :version "0.1"})
+    (db/add-jar help/*db* "test-user" {:name "rock" :group "tester" :version "0.1"}))
+  (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 1)))]
+    (db/add-jar help/*db* "test-user" {:name "rock" :group "tester" :version "0.2"})
+    (db/add-jar help/*db* "test-user" {:name "paper" :group "tester" :version "0.1"}))
+  (with-redefs [db/get-time (fn [] (java.sql.Timestamp. (long 2)))]
+    (db/add-jar help/*db* "test-user" {:name "scissors" :group "tester" :version "0.1"}))
     ; tests group_name and jar_name ordering
     (is (=
           '({:version "0.1", :jar_name "rock", :group_name "jester"}
             {:version "0.1", :jar_name "paper", :group_name "tester"})
           (->>
-            (db/browse-projects 1 2)
+            (db/browse-projects help/*db* 1 2)
             (map #(select-keys % [:group_name :jar_name :version])))))
 
     ; tests version ordering and pagination
@@ -355,20 +362,19 @@
           '({:version "0.2", :jar_name "rock", :group_name "tester"}
             {:version "0.1", :jar_name "scissors", :group_name "tester"})
           (->>
-            (db/browse-projects 2 2)
+            (db/browse-projects help/*db* 2 2)
             ( map #(select-keys % [:group_name :jar_name :version]))))))
 
 (deftest count-projects-works
-  (db/add-jar "test-user" {:name "rock" :group "jester" :version "0.1"})
-  (db/add-jar "test-user" {:name "rock" :group "tester" :version "0.1"})
-  (db/add-jar "test-user" {:name "rock" :group "tester" :version "0.2"})
-  (db/add-jar "test-user" {:name "paper" :group "tester" :version "0.1"})
-  (db/add-jar "test-user" {:name "scissors" :group "tester" :version "0.1"})
-  (is (= (db/count-all-projects) 4))
-  (is (= (db/count-projects-before "a") 0))
-  (is (= (db/count-projects-before "tester/rock") 2))
-  (is (= (db/count-projects-before "tester/rocks") 3))
-  (is (= (db/count-projects-before "z") 4)))
+  (db/add-jar help/*db* "test-user" {:name "rock" :group "jester" :version "0.1"})
+  (db/add-jar help/*db* "test-user" {:name "rock" :group "tester" :version "0.1"})
+  (db/add-jar help/*db* "test-user" {:name "rock" :group "tester" :version "0.2"})
+  (db/add-jar help/*db* "test-user" {:name "paper" :group "tester" :version "0.1"})
+  (db/add-jar help/*db* "test-user" {:name "scissors" :group "tester" :version "0.1"})
+  (is (= (db/count-all-projects help/*db*) 4))
+  (is (= (db/count-projects-before help/*db* "a") 0))
+  (is (= (db/count-projects-before help/*db* "tester/rock") 2))
+  (is (= (db/count-projects-before help/*db* "tester/rocks") 3))
+  (is (= (db/count-projects-before help/*db* "z") 4)))
 
-;; TODO: search tests?
 ;; TODO: recent-versions

--- a/test/clojars/test/unit/routes/api.clj
+++ b/test/clojars/test/unit/routes/api.clj
@@ -5,19 +5,23 @@
             [clojure.test :refer :all]
             [clojars.routes.api :as api]))
 
-(use-fixtures :each help/default-fixture help/index-fixture)
+(use-fixtures :each
+  help/default-fixture
+  help/index-fixture
+  help/with-clean-database)
 
 (def jarname "tester")
 (def jarmap {:name jarname :group jarname})
 
 (defn add-jar [i version & {:as override}]
   (with-redefs [db/get-time (fn [] (java.sql.Timestamp. i))]
-    (is (db/add-jar "test-user" (merge (assoc jarmap :version version) override)))))
+    (is (db/add-jar help/*db* "test-user" (merge (assoc jarmap :version version) override)))))
+
 
 (deftest only-release
   (add-jar 0 "0.1.0")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply db/find-jars-information args)]
+    (let [jars (apply db/find-jars-information help/*db* args)]
       (is (= 1 (count jars)))
       (is (= "0.1.0" (:latest_release (first jars))))
       (is (= "0.1.0" (:latest_version (first jars)))))))
@@ -26,7 +30,7 @@
   (add-jar 0 "0.1.0")
   (add-jar 1 "0.2.0")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply db/find-jars-information args)]
+    (let [jars (apply db/find-jars-information help/*db* args)]
       (is (= 1 (count jars)))
       (is (= "0.2.0" (:latest_release (first jars))))
       (is (= "0.2.0" (:latest_version (first jars)))))))
@@ -34,7 +38,7 @@
 (deftest only-snapshot
   (add-jar 0 "0.1.0-SNAPSHOT")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply db/find-jars-information args)]
+    (let [jars (apply db/find-jars-information help/*db* args)]
       (is (= 1 (count jars)))
       (is (not (:latest_release (first jars))))
       (is (= "0.1.0-SNAPSHOT" (:latest_version (first jars)))))))
@@ -43,7 +47,7 @@
   (add-jar 0 "0.1.0")
   (add-jar 1 "0.1.1-SNAPSHOT")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply db/find-jars-information args)]
+    (let [jars (apply db/find-jars-information help/*db* args)]
       (is (= 1 (count jars)))
       (is (= "0.1.0" (:latest_release (first jars))))
       (is (= "0.1.1-SNAPSHOT" (:latest_version (first jars)))))))
@@ -52,7 +56,7 @@
   (add-jar 0 "0.1.0-SNAPSHOT")
   (add-jar 1 "0.1.0")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply db/find-jars-information args)]
+    (let [jars (apply db/find-jars-information help/*db* args)]
       (is (= 1 (count jars)))
       (is (= "0.1.0" (:latest_release (first jars))))
       (is (= "0.1.0" (:latest_version (first jars)))))))
@@ -61,15 +65,15 @@
   (add-jar 0 "0.1.0")
   (add-jar 1 "0.1.0" :group "tester2")
   (doseq [args [[jarname] [jarname jarname] ["tester2" jarname]]]
-    (let [jars (apply db/find-jars-information args)]
+    (let [jars (apply db/find-jars-information help/*db* args)]
       (is (= 1 (count jars))))))
 
 (deftest multiple-jars-in-same-group
   (add-jar 0 "0.1.0")
   (add-jar 0 "0.1.0" :name "other")
-  (let [jars (db/find-jars-information jarname)]
+  (let [jars (db/find-jars-information help/*db* jarname)]
       (is (= 2 (count jars)))
       (is (= #{jarname "other"} (set (map :jar_name jars)))))
-  (let [jars (db/find-jars-information jarname jarname)]
+  (let [jars (db/find-jars-information help/*db* jarname jarname)]
       (is (= 1 (count jars)))
       (is (= jarname (-> jars first :jar_name)))))

--- a/test/clojars/test/unit/routes/api.clj
+++ b/test/clojars/test/unit/routes/api.clj
@@ -3,8 +3,7 @@
             [clojure.java.jdbc :as jdbc]
             [clojars.test.test-helper :as help]
             [clojure.test :refer :all]
-            [clojars.routes.api :as api]
-            [korma.core :refer [exec-raw]]))
+            [clojars.routes.api :as api]))
 
 (use-fixtures :each help/default-fixture help/index-fixture)
 
@@ -18,7 +17,7 @@
 (deftest only-release
   (add-jar 0 "0.1.0")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply api/find-jars args)]
+    (let [jars (apply db/find-jars-information args)]
       (is (= 1 (count jars)))
       (is (= "0.1.0" (:latest_release (first jars))))
       (is (= "0.1.0" (:latest_version (first jars)))))))
@@ -27,7 +26,7 @@
   (add-jar 0 "0.1.0")
   (add-jar 1 "0.2.0")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply api/find-jars args)]
+    (let [jars (apply db/find-jars-information args)]
       (is (= 1 (count jars)))
       (is (= "0.2.0" (:latest_release (first jars))))
       (is (= "0.2.0" (:latest_version (first jars)))))))
@@ -35,7 +34,7 @@
 (deftest only-snapshot
   (add-jar 0 "0.1.0-SNAPSHOT")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply api/find-jars args)]
+    (let [jars (apply db/find-jars-information args)]
       (is (= 1 (count jars)))
       (is (not (:latest_release (first jars))))
       (is (= "0.1.0-SNAPSHOT" (:latest_version (first jars)))))))
@@ -44,7 +43,7 @@
   (add-jar 0 "0.1.0")
   (add-jar 1 "0.1.1-SNAPSHOT")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply api/find-jars args)]
+    (let [jars (apply db/find-jars-information args)]
       (is (= 1 (count jars)))
       (is (= "0.1.0" (:latest_release (first jars))))
       (is (= "0.1.1-SNAPSHOT" (:latest_version (first jars)))))))
@@ -53,7 +52,7 @@
   (add-jar 0 "0.1.0-SNAPSHOT")
   (add-jar 1 "0.1.0")
   (doseq [args [[jarname] [jarname jarname]]]
-    (let [jars (apply api/find-jars args)]
+    (let [jars (apply db/find-jars-information args)]
       (is (= 1 (count jars)))
       (is (= "0.1.0" (:latest_release (first jars))))
       (is (= "0.1.0" (:latest_version (first jars)))))))
@@ -62,15 +61,15 @@
   (add-jar 0 "0.1.0")
   (add-jar 1 "0.1.0" :group "tester2")
   (doseq [args [[jarname] [jarname jarname] ["tester2" jarname]]]
-    (let [jars (apply api/find-jars args)]
+    (let [jars (apply db/find-jars-information args)]
       (is (= 1 (count jars))))))
 
 (deftest multiple-jars-in-same-group
   (add-jar 0 "0.1.0")
   (add-jar 0 "0.1.0" :name "other")
-  (let [jars (api/find-jars jarname)]
+  (let [jars (db/find-jars-information jarname)]
       (is (= 2 (count jars)))
       (is (= #{jarname "other"} (set (map :jar_name jars)))))
-  (let [jars (api/find-jars jarname jarname)]
+  (let [jars (db/find-jars-information jarname jarname)]
       (is (= 1 (count jars)))
       (is (= jarname (-> jars first :jar_name)))))

--- a/test/clojars/test/unit/web.clj
+++ b/test/clojars/test/unit/web.clj
@@ -4,7 +4,9 @@
             [clojars.test.test-helper :as help]
             [ring.mock.request :refer [request header]]))
 
-(use-fixtures :each help/default-fixture)
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database)
 
 (defn cookies [res]
   (flatten [(get-in res [:headers "Set-Cookie"])]))
@@ -16,16 +18,16 @@
   (every? #(.contains % "HttpOnly") (res cookies)))
 
 (deftest https-cookies-are-secure
-  (let [res (clojars.web/clojars-app (assoc (request :get "/") :scheme :https))]
+  (let [res ((web/clojars-app help/*db*) (assoc (request :get "/") :scheme :https))]
     (is (cookies-secure? res))
     (is (cookies-http-only? res))))
 
 (deftest forwarded-https-cookies-are-secure
-  (let [res (clojars.web/clojars-app (-> (request :get "/")
+  (let [res ((web/clojars-app help/*db*) (-> (request :get "/")
                                        (header "x-forward-proto" "https")))]
     (is (cookies-secure? res))
     (is (cookies-http-only? res))))
 
 (deftest regular-cookies-are-http-only
-  (let [res (clojars.web/clojars-app (request :get "/"))]
+  (let [res ((web/clojars-app help/*db*) (request :get "/"))]
     (is (cookies-http-only? res))))

--- a/test/clojars/test/unit/web/jar.clj
+++ b/test/clojars/test/unit/web/jar.clj
@@ -3,22 +3,28 @@
             [clojure.test :refer :all]
             [clojars.test.test-helper :as help]))
 
-(use-fixtures :each help/default-fixture)
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database)
 
 (deftest bad-homepage-url-shows-as-text
   (with-out-str
-    (let [html (jar/show-jar nil {:homepage "something thats not a url"
+    (let [html (jar/show-jar help/*db*
+                             nil {:homepage "something thats not a url"
                                   :created 3
                                   :version "1"
                                   :group_name "test"
-                                  :jar_name "test"} [] 0)]
+                                  :jar_name "test"}
+                             [] 0)]
       (is (re-find #"something thats not a url" html)))))
 
 (deftest pages-are-escaped
   (with-out-str
-    (let [html (jar/show-jar nil {:homepage nil
+    (let [html (jar/show-jar help/*db*
+                             nil {:homepage nil
                                   :created 3
                                   :version "<script>alert('hi')</script>"
                                   :group_name "test"
-                                  :jar_name "test"} [] 0)]
+                                  :jar_name "test"}
+                             [] 0)]
       (is (not (.contains html "<script>alert('hi')</script>"))))))


### PR DESCRIPTION
DB access drops down to sql in serveral places. Korma does not appear to be providing a good abstraction. This PR removes korma and replaces it with yesql + HikariCP. Using yesql allows sql to be in sql without the string concatenation that raw clojure.jdbc would require.

The tests see significant changes to account for the new apis. Additionally the fixtures change to allow keeping one connection to the database per test, and an in memory database is used.

The clojars admin namespace contains a dynamic var for its database connection.  The nrepl server uses some middleware to populate that var for connections.

The one off tasks (migrations,setup) are changed to use the new apis.

Unfortunatly `lein ring` no longer works as a database needs to be passed to the handler. I plan for a reloaded repl based workflow to replace the "dev server" functionality.

The majority of the line changes are for threading the database throughout the app. This allows the removal of one of the pieces of global state. It is a bit ugly as it shows some places that are using the database that could be done differently. Additionally, making it explicit is a step towards eventual component-ization of the app.

I believe this commit to be in a state that could be merged. However, changing out the db abstraction should be a consensus decision, so interested to hear comments on it.