### PR TITLE
Reloaded repl workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,42 +31,102 @@ We try to make releases fairly soon after merging contributions,
 but post to the mailing list if it's been a week or two and you'd like
 something pushed to the production website.
 
-Running the webapp
-------------------
+Development
+-----------
 
-There are several ways to run Clojars depending on what you intend to do with
-it. Regardless of how you run it, you first need to do some setup:
+### Development system
 
-1. Install [Leiningen](http://github.com/technomancy/leiningen)
-   * Mac OS X Homebrew: `brew install leiningen`
+To begin developing, start with a REPL.
 
-2. Run the DB migrations: `lein migrate`
+```sh
+lein repl
+```
 
-To run the application using Leinigen 2:
+Run `migrate` to initialize the database to the latest migration.
 
-1. Run the webapp: `lein run` (see `--help` for options)
+```clojure
+user=> (migrate)
+...
+```
+Run `go` to initiate and start the system.
 
-2. Now try hitting [localhost:8080](http://localhost:8080) in your web browser.
+```clojure
+user=> (go)
+:started
+```
 
-To build a standalone jar for deploying to a server:
+By default this creates a running development system at <http://localhost:8080>.
+
+When you make changes to your source files, use `reset` to reload any
+modified files and reset the server.
+
+```clojure
+user=> (reset)
+:reloading (...)
+:resumed
+```
+
+If you'd like to hack on the UI or search it might be useful to have
+production-like metadata. To create that, use
+`clojars.dev.setup/-main` to create test users, import an existing
+maven repository (your local `~/.m2/repository/` works well), and
+setup a search index:
+
+```sh
+cp -r ~/.m2/repository data/dev_repo
+lein run -m clojars.dev.setup
+```
+If you want to use the actual repo from clojars.org, you can grab it
+via [rsync](http://github.com/ato/clojars-web/wiki/Data).
+
+Note that this setup task isn't perfect - SNAPSHOTS won't have
+version-specific metadata (which won't matter for the operation of
+clojars, but may matter if you try to use the resulting repo as a real
+repo), and versions will be listed out of order on the project pages,
+but it should be good enough to test with.
+
+### Testing
+
+Testing is designed to work in a REPL to allow flow.
+
+```clojure
+user=> (test)
+...
+```
+
+```clojure
+user=> (test #'clojars.test.unit.db/added-users-can-be-found)
+...
+```
+
+Tests can also be run through Leiningen for CI.
+
+```sh
+lein test
+```
+
+### Production system with development config
+
+Occasionally it can be useful to start a production system based on the development
+configuration. This can be done by `lein run`.
+
+Deployment
+----------
+
+Also see [Configuration](#configuration).
 
 1. Compile with: `lein uberjar`
-
-2. Run the webapp: `java -jar target/clojars-web-*-standalone.jar`
-
-If you'd like to run it out of an editor/IDE environment you can
-probably eval a call to the `-main` function in
-`src/clojars/main.clj`.
+2. Deploy `target/uberjar/clojars-web-*-standalone.jar` to the server
+3. Run the migrations `java -cp clojars-web-*-standalone.jar clojure.main -m clojars.db.migrate`
+4. Run the production system: `java -jar clojars-web-*-standalone.jar`
 
 Configuration
 -------------
 
-All options are available as command-line switches.  Additionally some
-can be set using environment variables.  See `lein run -h` for the
+Some options can be set using environment variables.  See `lein run -h` for the
 full list.
 
-Options may be read from a file using the `-f` switch, setting the
-`CONFIG_FILE` environment variable or by putting a file named
+Options may be read from a file by putting a file named
 `config.clj` on the classpath.  The config file should be a bare
 Clojure map:
 
@@ -79,33 +139,12 @@ Clojure map:
             :from "noreply@clojars.org"
             :ssl false}}
 
-The classpath option can be used with Leiningen 2 profiles.  When
-running out of a source checkout using `lein run` the configuration
-will be read from `dev-resources/config.clj`.  When running automated
-tests with `lein test` then `test-resources/config.clj` is used.
+The classpath option can be used with lein profiles.  When
+running out of a source checkout using `lein run` or `lein repl` the
+configuration will be read from `dev-resources/config.clj`.
 
-
-Test data
----------
-
-If you'd like to hack on the UI or search it might be useful to have
-production-like metadata. To create that, use
-`clojars.dev.setup/-main` to create test users, import an existing
-maven repository (your local `~/.m2/repository/` works well), and
-setup a search index:
-
-    $ cp -r ~/.m2/repository data/dev_repo
-    $ lein run -m clojars.dev.setup
-
-If you want to use the actual repo from clojars.org, you can grab it
-via [rsync](http://github.com/ato/clojars-web/wiki/Data).
-
-Note that this setup task isn't perfect - SNAPSHOTS won't have
-version-specific metadata (which won't matter for the operation of
-clojars, but may matter if you try to use the resulting repo as a real
-repo), and versions will be listed out of order on the project pages,
-but it should be good enough to test with.
-
+When running automated tests at the repl, or with `lein test`, a test environment
+is used to provide isolation. It can be found in `test/clojars/test/test_helper.clj`.
 
 License
 -------

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,39 @@
+(ns user
+  (:require [clojure.repl :refer :all]
+            [clojure.pprint :refer [pprint]]
+            [clojure.tools.namespace.repl :refer [refresh]]
+            [clojure.java.io :as io]
+            [com.stuartsierra.component :as component]
+            [eftest.runner :as eftest]
+            [meta-merge.core :refer [meta-merge]]
+            [reloaded.repl :refer [system init start stop go reset]]
+            [clojars.config :as config]
+            [clojars.system :as system]
+            [clojars.db.migrate :as migrate]))
+
+(def dev-env
+  {:app {:middleware []}})
+
+
+(defn new-system []
+  (config/configure [])
+  (system/new-system (meta-merge config/config dev-env)))
+
+(ns-unmap *ns* 'test)
+
+(defn test [& tests]
+  (let [tests (if (empty? tests)
+                (eftest/find-tests "test")
+                tests)]
+    (eftest/run-tests tests {:report eftest.report.pretty/report
+                             :multithread? false})))
+
+(when (io/resource "local.clj")
+  (load "local"))
+
+(defn migrate []
+  (migrate/migrate config/config))
+
+;; TODO: function to setup fake data (from clojars.dev.setup?)
+
+(reloaded.repl/set-init! new-system)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject clojars-web "0.18.1-SNAPSHOT"
+  :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [yeller-clojure-client "1.2.1"]
@@ -36,17 +37,23 @@
                  [yesql "0.5.1"]
                  [com.zaxxer/HikariCP "2.4.1"]
                  [org.slf4j/slf4j-nop "1.7.7"]]
-  :profiles {:dev {:dependencies [[kerodon "0.7.0"]
-                                  [clj-http-lite "0.2.1"]]
-                   :resource-paths ["local-resources"]}}
-  :aliases {"migrate" ["run" "-m" "clojars.db.migrate"]}
-  :main clojars.main
-  :min-lein-version "2.0.0"
+  :main ^:skip-aot clojars.main
+  :target-path "target/%s/"
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
                   ["vcs" "commit"]
                   ["vcs" "tag"]
                   ["change" "version" "leiningen.release/bump-version"]
                   ["vcs" "commit"]
-                  ["vcs" "push"]])
-
+                  ["vcs" "push"]]
+  :aliases {"migrate" ["run" "-m" "clojars.db.migrate"]}
+  :profiles
+  {:dev  [:project/dev  :profiles/dev]
+   :test [:project/test :profiles/test]
+   :uberjar {:aot :all}
+   :profiles/dev  {}
+   :profiles/test {}
+   :project/dev   {:dependencies [[kerodon "0.7.0"]
+                                  [clj-http-lite "0.2.1"]]
+                   :resource-paths ["local-resources"]}
+   :project/test  {}})

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject clojars-web "0.18.1-SNAPSHOT"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [yeller-clojure-client "1.2.1"]
                  [org.apache.maven/maven-model "3.0.4"
@@ -12,7 +12,6 @@
                    commons-logging]]
                  [s3-wagon-private "1.0.0"]
                  [compojure "1.3.3"]
-                 [ring/ring-jetty-adapter "1.1.1"]
                  [ring-middleware-format "0.5.0"]
                  [hiccup "1.0.3"]
                  [cheshire "5.4.0"]
@@ -35,8 +34,11 @@
                  [org.bouncycastle/bcpg-jdk15on "1.47"]
                  [mvxcvi/clj-pgp "0.8.0"]
                  [yesql "0.5.1"]
-                 [com.zaxxer/HikariCP "2.4.1"]
-                 [org.slf4j/slf4j-nop "1.7.7"]]
+                 [com.stuartsierra/component "0.2.3"]
+                 [duct/hikaricp-component "0.1.0"]
+                 [duct "0.4.4"]
+                 [meta-merge "0.1.1"]
+                 [ring-jetty-component "0.3.0"]]
   :main ^:skip-aot clojars.main
   :target-path "target/%s/"
   :release-tasks [["vcs" "assert-committed"]
@@ -53,7 +55,13 @@
    :uberjar {:aot :all}
    :profiles/dev  {}
    :profiles/test {}
-   :project/dev   {:dependencies [[kerodon "0.7.0"]
-                                  [clj-http-lite "0.2.1"]]
+   :project/dev   {:source-paths ["dev"]
+                   :repl-options {:init-ns user}
+                   :dependencies [[reloaded.repl "0.2.0"]
+                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [eftest "0.1.0"]
+                                  [kerodon "0.7.0"
+                                   :exclusions [org.apache.httpcomponents/httpcore]]
+                                  [clj-http-lite "0.3.0"]]
                    :resource-paths ["local-resources"]}
    :project/test  {}})

--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -3,38 +3,18 @@
              [admin :as admin]
              [config :refer [config configure]]
              [errors :as errors]
-             [ring-servlet-patch :as patch]
+             [system :as system]
              [web :refer [clojars-app]]]
-            [ring.adapter.jetty :refer [run-jetty]])
-  (:import [com.zaxxer.hikari HikariConfig HikariDataSource])
+            [meta-merge.core :refer [meta-merge]]
+            [com.stuartsierra.component :as component])
   (:gen-class))
 
-(defn start-jetty [db & [port]]
-  (when-let [port (or port (:port config))]
-    (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" port))
-    (run-jetty (#'clojars-app db)
-               {:host (:bind config)
-                :port port
-                :join? false
-                :configurator patch/use-status-message-header})))
-
-(defn jdbc-url [db-config]
-  (if (string? db-config)
-    (if (.startsWith db-config "jdbc:")
-      db-config
-      (str "jdbc:" db-config))
-    (let [{:keys [subprotocol subname]} db-config]
-      (format "jdbc:%s:%s" subprotocol subname))))
+(def prod-env
+  {:app {:middleware []}})
 
 (defn -main [& args]
-  (alter-var-root #'*read-eval* (constantly false))
   (configure args)
   (errors/register-global-exception-handler!)
-  (let [url (jdbc-url (:db config))
-        db {:datasource (HikariDataSource. (doto (HikariConfig.) (.setJdbcUrl url)))}]
-    (start-jetty db)
-    (admin/init db)))
-
-(comment
-  (def server (start-jetty (jdbc-url (:db config)) 8080))
-  (.stop server))
+  (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" (:port config)))
+  (let [system (component/start (system/new-system (meta-merge config prod-env)))]
+    (admin/init (get-in system [:db :spec]))))

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -1,0 +1,41 @@
+(ns clojars.system
+  (:require [clojars
+             [ring-servlet-patch :as patch]
+             [web :as web]]
+            [com.stuartsierra.component :as component]
+            [duct.component
+             [endpoint :refer [endpoint-component]]
+             [handler :refer [handler-component]]
+             [hikaricp :refer [hikaricp]]]
+            [meta-merge.core :refer [meta-merge]]
+            [ring.component.jetty :refer [jetty-server]]))
+
+(def base-env
+  {:app {:middleware []}
+   :http {:configurator patch/use-status-message-header}})
+
+(defn jdbc-url [db-config]
+  (if (string? db-config)
+    (if (.startsWith db-config "jdbc:")
+      db-config
+      (str "jdbc:" db-config))
+    (let [{:keys [subprotocol subname]} db-config]
+      (format "jdbc:%s:%s" subprotocol subname))))
+
+(defn translate [config]
+  (let [{:keys [port bind db]} config]
+    (assoc config
+           :http {:port port :host bind}
+           :db {:uri (jdbc-url db)})))
+
+(defn new-system [config]
+  (let [config (meta-merge base-env (translate config))]
+    (-> (component/system-map
+         :app  (handler-component (:app config))
+         :http (jetty-server (:http config))
+         :db   (hikaricp (:db config))
+         :clojars-app   (endpoint-component web/handler-optioned))
+        (component/system-using
+         {:http [:app]
+          :app  [:clojars-app]
+          :clojars-app [:db]}))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -133,3 +133,6 @@
        (wrap-resource "public")
        (wrap-file-info)
        wrap-exceptions)))
+
+(defn handler-optioned [{:keys [db] :as opts}]
+  (clojars-app (:spec db)))


### PR DESCRIPTION
Introduce a user.clj based repl workflow for development This allows starting, stopping, refreshing files, and testing to occur from the repl. The README has been updated with a new development section showing how to get started.

Much of this is based on the the duct template, including updating the project.clj to current best practices.