### PR TITLE
Move exception handling for repo to middleware

### DIFF
--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -116,6 +116,7 @@
                   :allow-anon? false
                   :unauthenticated-handler
                   (partial workflows/http-basic-deny "clojars")})
+                (repo/wrap-exceptions)
                 (repo/wrap-file (:repo config))
                 (repo/wrap-reject-double-dot)))
    (-> (main-routes db)


### PR DESCRIPTION
This allows the routes to be free of needing to know how errors are reported.