### PR TITLE
Move yeller into a component and protocolize api

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.cli "0.2.1"]
-                 [yeller-clojure-client "1.2.1"]
+                 [yeller-clojure-client "1.4.1"]
                  [org.apache.maven/maven-model "3.0.4"
                   :exclusions
                   [org.codehaus.plexus/plexus-utils]]

--- a/src/clojars/main.clj
+++ b/src/clojars/main.clj
@@ -2,19 +2,29 @@
   (:require [clojars
              [admin :as admin]
              [config :refer [config configure]]
-             [errors :as errors]
-             [system :as system]
-             [web :refer [clojars-app]]]
+             [errors :as errors :refer [->StdOutReporter multiple-reporters]]
+             [system :as system]]
+            [com.stuartsierra.component :as component]
             [meta-merge.core :refer [meta-merge]]
-            [com.stuartsierra.component :as component])
+            [yeller.clojure.client :as yeller])
   (:gen-class))
 
 (def prod-env
   {:app {:middleware []}})
 
+(defn prod-system [config yeller]
+  (-> (meta-merge config prod-env)
+      system/new-system
+      (assoc :error-reporter (multiple-reporters
+                              (->StdOutReporter)
+                              yeller))))
+
 (defn -main [& args]
   (configure args)
-  (errors/register-global-exception-handler!)
-  (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" (:port config)))
-  (let [system (component/start (system/new-system (meta-merge config prod-env)))]
-    (admin/init (get-in system [:db :spec]))))
+  (println "clojars-web: enabling yeller client")
+  (let [yeller (yeller/client {:token (:yeller-token config)
+                               :environment (:yeller-environment config)})]
+    (Thread/setDefaultUncaughtExceptionHandler yeller)
+    (let [system (component/start (prod-system))]
+      (println "clojars-web: starting jetty on" (str "http://" (:bind config) ":" (:port config)))
+      (admin/init (get-in system [:db :spec])))))

--- a/src/clojars/maven.clj
+++ b/src/clojars/maven.clj
@@ -58,14 +58,14 @@
         filename (format "%s-%s-%s.pom" jar_name (re-find #"\S+(?=-SNAPSHOT$)" version) snapshot)]
     (io/file (directory-for jar) filename)))
 
-(defn jar-to-pom-map [{:keys [jar_name version] :as jar}]
+(defn jar-to-pom-map [reporter {:keys [jar_name version] :as jar}]
   (try
     (let [pom-file (if (re-find #"SNAPSHOT$" version)
                      (snapshot-pom-file jar)
                      (io/file (directory-for jar) (format "%s-%s.%s" jar_name version "pom")))]
       (pom-to-map (str pom-file)))
     (catch IOException e
-      (report-error (ex-info "Failed to create pom map" jar e))
+      (report-error reporter (ex-info "Failed to create pom map" jar e))
       nil)))
 
 (defn github-info [pom-map]

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -180,12 +180,12 @@
       {:status 400 :headers {}}
       (f req))))
 
-(defn wrap-exceptions [app]
+(defn wrap-exceptions [app reporter]
   (fn [req]
     (try
       (app req)
       (catch Exception e
-        (report-error e)
+        (report-error reporter e)
         (let [data (ex-data e)]
           {:status (or (:status data) 403)
            :headers {"status-message" (:status-message data)}

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -38,4 +38,4 @@
         (component/system-using
          {:http [:app]
           :app  [:clojars-app]
-          :clojars-app [:db]}))))
+          :clojars-app [:db :error-reporter]}))))

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -82,9 +82,9 @@
                                    "/promote/" (:version jar))]
                        (submit-button "Promote")))))))
 
-(defn show-jar [db account jar recent-versions count]
+(defn show-jar [db reporter account jar recent-versions count]
   (html-doc account (str (:jar_name jar) " " (:version jar))
-            (let [pom-map (jar-to-pom-map jar)]
+            (let [pom-map (jar-to-pom-map reporter jar)]
               [:div.light-article.row
                [:div#jar-title.col-sm-9.col-lg-9.col-xs-12.col-md-9
                 [:h1 (jar-link jar)]

--- a/test/clojars/test/integration/api.clj
+++ b/test/clojars/test/integration/api.clj
@@ -36,7 +36,7 @@
   (is (= (get-content-type {:headers {"content-type" "application/json;charset=utf-8"}}) "application/json")))
 
 (deftest an-api-test
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (inject-artifacts-into-repo! help/*db* "dantheman" "test.jar" "test-0.0.1/test.pom")
   (inject-artifacts-into-repo! help/*db* "dantheman" "test.jar" "test-0.0.2/test.pom")

--- a/test/clojars/test/integration/jars.clj
+++ b/test/clojars/test/integration/jars.clj
@@ -16,7 +16,7 @@
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.2/test.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/fake/test")
       (within [:div#jar-title :h1 :a]
               (has (text? "fake/test")))
@@ -27,7 +27,7 @@
 
 (deftest jars-with-only-snapshots-can-be-viewed
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/fake/test")
       (within [:div#jar-title :h1 :a]
               (has (text? "fake/test")))
@@ -42,7 +42,7 @@
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.1/fake.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.2/fake.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.3-SNAPSHOT/fake.pom")
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/fake")
       (within [:div#jar-title :h1 :a]
               (has (text? "fake")))
@@ -55,7 +55,7 @@
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.1/test.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.2/test.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "test.jar" "test-0.0.3-SNAPSHOT/test.pom")
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/fake/test")
       (follow "0.0.3-SNAPSHOT")
       (within [:div#jar-title :h1 :a]
@@ -69,7 +69,7 @@
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.1/fake.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.2/fake.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.3-SNAPSHOT/fake.pom")
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/fake")
       (follow "0.0.1")
       (within [:div#jar-title :h1 :a]
@@ -83,7 +83,7 @@
 (deftest canonical-jars-can-view-dependencies
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.1/fake.pom")
   (inject-artifacts-into-repo! help/*db* "someuser" "fake.jar" "fake-0.0.2/fake.pom")
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/fake")
       (within [:ul#dependencies]
                (has (text? "org.clojure/clojure 1.3.0-beta1")))))

--- a/test/clojars/test/integration/responses.clj
+++ b/test/clojars/test/integration/responses.clj
@@ -12,20 +12,20 @@
   help/with-clean-database)
 
 (deftest respond-404
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/nonexistent-route")
       (has (status? 404))
       (within [:title]
               (has (text? "Page not found - Clojars")))))
 
 (deftest respond-404-for-non-existent-group
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/groups/nonexistent.group")
       (has (status? 404))
       (within [:title]
               (has (text? "Page not found - Clojars")))))
 
 (deftest respond-405-for-puts
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/nonexistent-route" :request-method :put)
       (has (status? 405))))

--- a/test/clojars/test/integration/sessions.clj
+++ b/test/clojars/test/integration/sessions.clj
@@ -16,7 +16,7 @@
   help/with-clean-database)
 
 (deftest user-cant-login-with-bad-user-pass-combo
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (login-as "fixture@example.org" "password")
       (follow-redirect)
       (has (status? 200))
@@ -24,7 +24,7 @@
               (has (text? "Incorrect username and/or password.")))))
 
 (deftest user-can-login-and-logout
-  (let [app (web/clojars-app help/*db*)]
+  (let [app (help/app)]
     (-> (session app)
         (register-as "fixture" "fixture@example.org" "password"))
     (doseq [login ["fixture@example.org" "fixture"]]
@@ -41,7 +41,7 @@
                   (has (text? "login")))))))
 
 (deftest user-with-password-wipe-gets-message
-  (let [app (web/clojars-app help/*db*)]
+  (let [app (help/app)]
     (-> (session app)
         (register-as "fixture" "fixture@example.org" "password"))
     (jdbc/db-do-commands help/*db*

--- a/test/clojars/test/integration/uploads.clj
+++ b/test/clojars/test/integration/uploads.clj
@@ -20,7 +20,7 @@
   help/run-test-app)
 
 (deftest user-can-register-and-deploy
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (help/delete-file-recursively help/local-repo)
   (help/delete-file-recursively help/local-repo2)
@@ -45,7 +45,7 @@
           :repositories {"test" {:url
                                  (str "http://localhost:" help/test-port "/repo")}}
           :local-repo help/local-repo2)))
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/groups/org.clojars.dantheman")
       (has (status? 200))
       (within [:#content-wrapper
@@ -57,7 +57,7 @@
       (has (status? 200))
       (within [:#jar-sidebar :li.homepage :a]
               (has (text? "https://example.org"))))
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/")
       (fill-in [:#search] "test")
       (press [:#search-button])
@@ -67,7 +67,7 @@
               (has (text? "fake/test 0.0.1")))))
 
 (deftest user-can-deploy-to-new-group
-   (-> (session (clojars-app help/*db*))
+   (-> (session (help/app))
        (register-as "dantheman" "test@example.org" "password"))
    (help/delete-file-recursively help/local-repo)
    (help/delete-file-recursively help/local-repo2)
@@ -85,7 +85,7 @@
            :repositories {"test" {:url
                                   (str "http://localhost:" help/test-port "/repo")}}
            :local-repo help/local-repo2)))
-   (-> (session (clojars-app help/*db*))
+   (-> (session (help/app))
        (visit "/groups/fake")
        (has (status? 200))
        (within [:#content-wrapper
@@ -99,9 +99,9 @@
                (has (text? "https://example.org")))))
 
 (deftest user-cannot-deploy-to-groups-without-permission
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password"))
   (is (thrown-with-msg? org.sonatype.aether.deployment.DeploymentException
         #"Forbidden"
@@ -115,7 +115,7 @@
          :local-repo help/local-repo))))
 
 (deftest user-cannot-redeploy
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (aether/deploy
    :coordinates '[org.clojars.dantheman/test "0.0.1"]
@@ -138,7 +138,7 @@
           :local-repo help/local-repo))))
 
 (deftest user-can-redeploy-snapshots
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (aether/deploy
    :coordinates '[org.clojars.dantheman/test "0.0.3-SNAPSHOT"]
@@ -158,7 +158,7 @@
    :local-repo help/local-repo))
 
 (deftest user-can-deploy-snapshot-with-dot
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (aether/deploy
    :coordinates '[org.clojars.dantheman/test.thing "0.0.3-SNAPSHOT"]
@@ -191,7 +191,7 @@
          :local-repo help/local-repo))))
 
 (deftest deploy-requires-lowercase-group
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (is (thrown-with-msg? org.sonatype.aether.deployment.DeploymentException
         #"Forbidden - group names must consist solely of lowercase"
@@ -205,7 +205,7 @@
          :local-repo help/local-repo))))
 
 (deftest deploy-requires-lowercase-project
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (is (thrown-with-msg? org.sonatype.aether.deployment.DeploymentException
         #"Forbidden - project names must consist solely of lowercase"
@@ -219,7 +219,7 @@
          :local-repo help/local-repo))))
 
 (deftest deploy-requires-ascii-version
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (is (thrown-with-msg? org.sonatype.aether.deployment.DeploymentException
         #"Forbidden - version strings must consist solely of letters"
@@ -233,7 +233,7 @@
          :local-repo help/local-repo))))
 
 (deftest put-on-html-fails
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/repo/group/artifact/1.0.0/injection.html"
              :request-method :put
@@ -247,7 +247,7 @@
       (has (status? 400))))
 
 (deftest put-using-dotdot-fails
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/repo/../artifact/1.0.0/test.jar" :request-method :put
              :headers {"authorization"
@@ -289,10 +289,10 @@
       (has (status? 400))))
 
 (deftest does-not-write-incomplete-file
-  (-> (session (clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password"))
   (with-out-str
-    (-> (session (clojars-app help/*db*))
+    (-> (session (help/app))
         (visit "/repo/group3/artifact3/1.0.0/test.jar"
                :body (proxy [java.io.InputStream] []
                        (read

--- a/test/clojars/test/integration/users.clj
+++ b/test/clojars/test/integration/users.clj
@@ -12,7 +12,7 @@
   help/with-clean-database)
 
 (deftest user-can-register
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password")
       (follow-redirect)
       (has (status? 200))
@@ -20,9 +20,9 @@
               (has (text? "Dashboard (dantheman)")))))
 
 (deftest bad-registration-info-should-show-error
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password"))
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/")
       (follow "register")
       (has (status? 200))
@@ -78,7 +78,7 @@
               (has (text? "Username is already taken")))))
 
 (deftest user-can-update-info
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password")
       (follow-redirect)
       (follow "profile")
@@ -101,7 +101,7 @@
               (has (text? "Dashboard (fixture)")))))
 
 (deftest bad-update-info-should-show-error
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password")
       (follow-redirect)
       (follow "profile")
@@ -124,9 +124,9 @@
 (deftest user-can-get-new-password
   (let [transport (promise)]
     (with-redefs [clojars.email/send-out (fn [x] (deliver transport x))]
-      (-> (session (web/clojars-app help/*db*))
+      (-> (session (help/app))
           (register-as "fixture" "fixture@example.org" "password"))
-      (-> (session (web/clojars-app help/*db*))
+      (-> (session (help/app))
           (visit "/")
           (follow "login")
           (follow "Forgot password?")
@@ -152,7 +152,7 @@
                 #"Hello,\n\nWe received a request from someone, hopefully you, to reset the password of your clojars user.\n\nTo contine with the reset password process, click on the following link:\n\n([^ ]+)"
                 (.getContent (.getMimeMessage email)))]
           (is (seq reset-password-link))
-          (-> (session (web/clojars-app help/*db*))
+          (-> (session (help/app))
               (visit reset-password-link)
               (has (status? 200))
               (fill-in "New password" password)
@@ -171,16 +171,16 @@
                       (has (text? "Dashboard (fixture)")))))))))
 
 (deftest bad-reset-code-shows-message
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/password-resets/this-code-does-not-exist")
       (has (status? 200))
       (within [:p]
         (has (text? "The reset code was not found. Please ask for a new code in the forgot password page")))))
 
 (deftest member-can-add-user-to-group
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "fixture" "fixture@example.org" "password"))
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "fixture")
@@ -190,7 +190,7 @@
               (has (text? "danthemanfixture")))))
 
 (deftest user-must-exist-to-be-added-to-group
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "fixture")
@@ -199,7 +199,7 @@
               (has (text? "No such user: fixture")))))
 
 (deftest users-can-be-viewed
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password")
       (visit "/users/dantheman")
       (within [:div.light-article :> :h1]

--- a/test/clojars/test/integration/web.clj
+++ b/test/clojars/test/integration/web.clj
@@ -13,22 +13,22 @@
   help/with-clean-database)
 
 (deftest server-errors-display-error-page
-  (with-out-str (-> (session (web/clojars-app help/*db*))
+  (with-out-str (-> (session (help/app))
              (visit "/error")
                     (within [:div.small-section :> :h1]
                       (has (text? "Oops!"))))))
 
 (deftest error-page-includes-error-id
   (with-redefs [clojars.errors/error-id (constantly "ERROR")]
-    (with-out-str (-> (session (web/clojars-app help/*db*))
+    (with-out-str (-> (session (help/app))
                     (visit "/error")
                     (within [:div.small-section :> :pre.error-id]
                       (has (text? "error-id:\"ERROR\"")))))))
 
 (deftest server-errors-log-caught-exceptions
   (let [err (atom nil)]
-    (with-redefs [clojars.errors/report-error (fn [e & _] (reset! err e))]
-      (-> (session (web/clojars-app help/*db*))
+    (with-redefs [clojars.errors/report-error (fn [r e & _] (reset! err e))]
+      (-> (session (help/app))
         (visit "/error"))
       (is (re-find #"You really want an error" (.getMessage @err))))))
 
@@ -38,7 +38,7 @@
      help/*db*
       "test-user"
       {:name (str "tester" i) :group "tester" :version "0.1" :description "Huh" :authors ["Zz"]}))
-   (-> (session (web/clojars-app help/*db*))
+   (-> (session (help/app))
      (visit "/projects")
      (within [:div.light-article :> :h1]
              (has (text? "All projects")))
@@ -63,7 +63,7 @@
      help/*db*
       "test-user"
       {:name (str "tester" i "a") :group "tester" :version "0.1" :description "Huh" :authors ["Zz"]}))
-  (-> (session (web/clojars-app help/*db*))
+  (-> (session (help/app))
       (visit "/projects")
       (fill-in "Enter a few letters..." "tester/tester123")
       (press "Jump")

--- a/test/clojars/test/unit/web.clj
+++ b/test/clojars/test/unit/web.clj
@@ -18,16 +18,16 @@
   (every? #(.contains % "HttpOnly") (res cookies)))
 
 (deftest https-cookies-are-secure
-  (let [res ((web/clojars-app help/*db*) (assoc (request :get "/") :scheme :https))]
+  (let [res ((help/app) (assoc (request :get "/") :scheme :https))]
     (is (cookies-secure? res))
     (is (cookies-http-only? res))))
 
 (deftest forwarded-https-cookies-are-secure
-  (let [res ((web/clojars-app help/*db*) (-> (request :get "/")
+  (let [res ((help/app) (-> (request :get "/")
                                        (header "x-forward-proto" "https")))]
     (is (cookies-secure? res))
     (is (cookies-http-only? res))))
 
 (deftest regular-cookies-are-http-only
-  (let [res ((web/clojars-app help/*db*) (request :get "/"))]
+  (let [res ((help/app) (request :get "/"))]
     (is (cookies-http-only? res))))

--- a/test/clojars/test/unit/web/jar.clj
+++ b/test/clojars/test/unit/web/jar.clj
@@ -8,23 +8,23 @@
   help/with-clean-database)
 
 (deftest bad-homepage-url-shows-as-text
-  (with-out-str
-    (let [html (jar/show-jar help/*db*
-                             nil {:homepage "something thats not a url"
-                                  :created 3
-                                  :version "1"
-                                  :group_name "test"
-                                  :jar_name "test"}
-                             [] 0)]
-      (is (re-find #"something thats not a url" html)))))
+  (let [html (jar/show-jar help/*db*
+                           (help/quiet-reporter)
+                           nil {:homepage "something thats not a url"
+                                :created 3
+                                :version "1"
+                                :group_name "test"
+                                :jar_name "test"}
+                           [] 0)]
+    (is (re-find #"something thats not a url" html))))
 
 (deftest pages-are-escaped
-  (with-out-str
-    (let [html (jar/show-jar help/*db*
-                             nil {:homepage nil
-                                  :created 3
-                                  :version "<script>alert('hi')</script>"
-                                  :group_name "test"
-                                  :jar_name "test"}
-                             [] 0)]
-      (is (not (.contains html "<script>alert('hi')</script>"))))))
+  (let [html (jar/show-jar help/*db*
+                           (help/quiet-reporter)
+                           nil {:homepage nil
+                                :created 3
+                                :version "<script>alert('hi')</script>"
+                                :group_name "test"
+                                :jar_name "test"}
+                           [] 0)]
+    (is (not (.contains html "<script>alert('hi')</script>")))))


### PR DESCRIPTION
Several places were using error reporting through yeller. This patch
threads an ErrorReporter though the app. A protocol is used to allow
injection of specific implementations for each system. The production
system gets an implementation that prints to stdout and reports to
yeller. The development system gets an implementation that only prints
to stdout.  Testing gets an implementation that ignores errors, as the
resulting test failure should provide context.

This allows us to have quiet tests on success again!