### PR TITLE
Database protocol

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [commons-codec "1.6"]
                  [net.cgrand/regex "1.0.1"
                   :exclusions [org.clojure/clojure]]
-                 [clj-time "0.9.0"]
+                 [clj-time "0.11.0"]
                  [com.cemerick/friend "0.2.1"
                   :exclusions [org.clojure/core.cache
                                org.apache.httpcomponents/httpclient

--- a/resources/queries/sqlite-queryfile.sql
+++ b/resources/queries/sqlite-queryfile.sql
@@ -63,7 +63,7 @@ ORDER BY j.group_name ASC, j.jar_name ASC;
 SELECT j.*
 FROM jars j
 JOIN (
-  SELECT  jar_name, MAX(created) AS created
+  SELECT jar_name, MAX(created) AS created
   FROM jars
   GROUP BY group_name, jar_name
 ) l

--- a/src/clojars/admin.clj
+++ b/src/clojars/admin.clj
@@ -6,11 +6,12 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.nrepl.server :as nrepl])
-  (:import java.text.SimpleDateFormat
+  (:import java.util.Date
+           java.text.SimpleDateFormat
            org.apache.commons.io.FileUtils))
 
 (defn current-date-str []
-  (.format (SimpleDateFormat. "yyyyMMdd") (db/get-time)))
+  (.format (SimpleDateFormat. "yyyyMMdd") (Date.)))
 
 (def ^:dynamic *db*)
 

--- a/src/clojars/auth.clj
+++ b/src/clojars/auth.clj
@@ -1,6 +1,11 @@
 (ns clojars.auth
   (:require [cemerick.friend :as friend]
-            [clojars.db :refer [group-membernames]]))
+            [clojars.db :refer [group-membernames]]
+            [cemerick.friend.credentials :as creds]
+            [clojars.config :refer [config]]))
+
+(defn bcrypt [s]
+  (creds/hash-bcrypt s :work-factor (:bcrypt-work-factor config)))
 
 (defmacro with-account [body]
   `(friend/authenticated (try-account ~body)))

--- a/src/clojars/components/serial_sqlite.clj
+++ b/src/clojars/components/serial_sqlite.clj
@@ -1,0 +1,224 @@
+(ns clojars.components.serial-sqlite
+  (:require [clojars.db :as db]
+            [clojars.db.sql :as sql]
+            [com.stuartsierra.component :as component])
+  (:import java.util.concurrent.Executors))
+
+(def ^:private ^:dynamic *in-executor* nil)
+
+(defn serialize-task* [task-name executor task]
+  (if *in-executor*
+    (task)
+    (binding [*in-executor* true]
+      (let [bound-f (bound-fn []
+                      (try
+                        (task)
+                        (catch Throwable e
+                          e)))
+            response (deref
+                      (.submit executor bound-f)
+                      10000 ::timeout)]
+        (cond
+          (= response ::timeout) (throw
+                                  (ex-info
+                                   "Timed out waiting for serialized task to run"
+                                   {:name task-name}))
+          (instance? Throwable response) (throw
+                                          (ex-info "Serialized task failed"
+                                                   {:name task-name}
+                                                   response))
+          :default response)))))
+
+(defmacro serialize-task [name & body]
+  `(serialize-task* ~name ~'executor
+                    (^:once fn* [] ~@body)))
+
+(defrecord SerialSqlite [db executor]
+  component/Lifecycle
+  (start [this]
+    (if executor
+      this
+      (assoc this :executor (Executors/newSingleThreadExecutor))))
+  (stop [this]
+    (when executor
+      (.shutdown executor))
+    (assoc this executor nil))
+  db/Database
+  (find-user [this username]
+    (sql/find-user {:username username}
+                   {:connection db
+                    :result-set-fn first}))
+  (find-user-by-user-or-email [this username-or-email]
+    (sql/find-user-by-user-or-email {:username_or_email username-or-email}
+                                    {:connection db
+                                     :result-set-fn first}))
+  (find-user-by-password-reset-code [this reset-code time]
+    (sql/find-user-by-password-reset-code {:reset_code reset-code
+                                           :reset_code_created_at time}
+                                          {:connection db
+                                           :result-set-fn first}))
+  (jars-by-username [this username]
+      (sql/jars-by-username {:username username}
+                            {:connection db}))
+
+  (add-user [this email username password pgp-key time]
+    (let [record {:email email, :username username, :password password,
+                :pgp_key pgp-key :created time}
+        groupname (str "org.clojars." username)]
+      (serialize-task :add-user
+                      (sql/insert-user! record
+                                        {:connection db})
+                      (sql/insert-group! {:groupname groupname :username username}
+                                         {:connection db}))
+      record))
+  (update-user [this account email username password pgp-key]
+    (let [fields {:email email
+                :username username
+                :pgp_key pgp-key
+                :account account
+                :password password}]
+      (serialize-task :update-user
+                      (sql/update-user! fields
+                                        {:connection db}))
+      fields))
+  (update-user-password [this reset-code password]
+    (serialize-task :update-user-password
+                    (sql/update-user-password! {:password password
+                                                :reset_code reset-code}
+                                               {:connection db})))
+  (set-password-reset-code! [this username-or-email reset-code time]
+    (serialize-task :set-password-reset-code
+                    (sql/set-password-reset-code! {:reset_code reset-code
+                                                   :reset_code_created_at time
+                                                   :username_or_email username-or-email}
+                                                  {:connection db})))
+
+  (find-groupnames [this username]
+    (sql/find-groupnames {:username username}
+                         {:connection db
+                          :row-fn :name}))
+  (group-membernames [this groupname]
+    (sql/group-membernames {:groupname groupname}
+                           {:connection db
+                            :row-fn :user}))
+  (group-keys [this groupname]
+    (sql/group-keys {:groupname groupname}
+                    {:connection db
+                     :row-fn :pgp_key}))
+  (jars-by-groupname [this groupname]
+    (sql/jars-by-groupname {:groupname groupname}
+                           {:connection db}))
+  (add-member [this groupname username added-by]
+    (serialize-task :add-member
+                    (sql/add-member! {:groupname groupname
+                                      :username username
+                                      :added_by added-by}
+                                     {:connection db})))
+  (delete-groups [this group-id]
+    (serialize-task :delete-groups
+                    (sql/delete-group! {:group_id group-id}
+                                       {:connection db})))
+
+  (recent-versions [this groupname jarname]
+    (sql/recent-versions {:groupname groupname
+                          :jarname jarname}
+                         {:connection db}))
+  (recent-versions [this groupname jarname num]
+    (sql/recent-versions-limit {:groupname groupname
+                                :jarname jarname
+                                :num num}
+                               {:connection db}))
+  (count-versions [this groupname jarname]
+    (sql/count-versions {:groupname groupname
+                       :jarname jarname}
+                      {:connection db
+                       :result-set-fn first
+                       :row-fn :count}))
+  (recent-jars [this]
+    (sql/recent-jars {} {:connection db}))
+  (jar-exists [this groupname jarname]
+    (sql/jar-exists {:groupname groupname
+                   :jarname jarname}
+                  {:connection db
+                   :result-set-fn first
+                   :row-fn #(= % 1)}))
+  (find-jar [this groupname jarname]
+    (sql/find-jar {:groupname groupname
+                   :jarname jarname}
+                  {:connection db
+                   :result-set-fn first}))
+  (find-jar [this groupname jarname version]
+    (sql/find-jar-versioned {:groupname groupname
+                             :jarname jarname
+                             :version version}
+                            {:connection db
+                             :result-set-fn first}))
+  (all-projects [this offset limit]
+    (sql/all-projects {:num limit
+                       :offset offset}
+                      {:connection db}))
+  (count-all-projects [this]
+    (sql/count-all-projects {}
+                            {:connection db
+                             :result-set-fn first
+                             :row-fn :count}))
+  (count-projects-before [this s]
+    (sql/count-projects-before {:s s}
+                               {:connection db
+                                :result-set-fn first
+                                :row-fn :count}))
+
+  (find-jars-information [this group-id]
+    (db/find-jars-information this group-id nil))
+  (find-jars-information [this group-id artifact-id]
+    (if artifact-id
+      (sql/find-jars-information {:group_id group-id
+                                  :artifact_id artifact-id}
+                                 {:connection db})
+      (sql/find-groups-jars-information {:group_id group-id}
+                                        {:connection db})))
+  (promote [this group name version time]
+    (serialize-task :promote
+                    (sql/promote! {:group_id group
+                                   :artifact_id name
+                                   :version version
+                                   :promoted_at time}
+                                  {:connection db})))
+  (promoted? [this group-id artifact-id version]
+    (sql/promoted {:group_id group-id
+                   :artifact_id artifact-id
+                   :version version}
+                  {:connection db
+                   :result-set-fn first
+                   :row-fn :promoted_at}))
+  
+  (add-jar [this account {:keys [group name version
+                                 description homepage authors] :as jarmap} time]
+    (serialize-task :add-jar
+                    (sql/add-jar! {:groupname group
+                                   :jarname   name
+                                   :version   version
+                                   :user      account
+                                   :created    time
+                                   :description description
+                                   :homepage   homepage
+                                   :authors    authors}
+                                  {:connection db})))
+  (delete-jars [this group-id]
+    (serialize-task :delete-jars
+                    (sql/delete-groups-jars! {:group_id group-id}
+                                             {:connection db})))
+  (delete-jars [this group-id jar-id]
+    (serialize-task :delete-jars
+                    (sql/delete-jars! {:group_id group-id
+                                       :jar_id jar-id}
+                                      {:connection db})))
+  (delete-jars [this group-id jar-id version]
+    (serialize-task :delete-jars
+                    (sql/delete-jar-version! {:group_id group-id
+                                              :jar_id jar-id
+                                              :version version}
+                                             {:connection db}))))
+
+(defn connector []
+  (map->SerialSqlite {}))

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -1,236 +1,46 @@
-(ns clojars.db
-  (:require [clojars.db.sql :as sql]
-            [clojure.string :as str]
-            [clj-time.jdbc])
-  (:import java.util.concurrent.Executors))
+(ns clojars.db)
 
-(defn find-user [db username]
-  (sql/find-user {:username username}
-                 {:connection db
-                  :result-set-fn first}))
+(defprotocol Database
+  (find-user [this username])
+  (find-user-by-user-or-email [this username-or-email])
+  (find-user-by-password-reset-code [this reset-code time])
+  (jars-by-username [this username])
 
-(defn find-user-by-user-or-email [db username-or-email]
-  (sql/find-user-by-user-or-email {:username_or_email username-or-email}
-                                  {:connection db
-                                   :result-set-fn first}))
+  (add-user [this email username password pgp-key time])
+  (update-user [this account email username password pgp-key])
+  (update-user-password [this reset-code password])
+  (set-password-reset-code! [this username-or-email reset-code time])
 
-(defn find-user-by-password-reset-code [db reset-code time]
-  (sql/find-user-by-password-reset-code {:reset_code reset-code
-                                         :reset_code_created_at time}
-                                        {:connection db
-                                         :result-set-fn first}))
+  (find-groupnames [this username])
+  (group-membernames [this groupname])
+  (group-keys [this groupname])
+  (jars-by-groupname [this groupname])
+  (add-member [this groupname username added-by])
+  ;; does not delete jars in the group. should it?
+  (delete-groups [this group-id])
 
-(defn find-groupnames [db username]
-  (sql/find-groupnames {:username username}
-                       {:connection db
-                        :row-fn :name}))
+  (recent-versions
+    [this groupname jarname]
+    [this groupname jarname num])
+  (count-versions [this groupname jarname])
+  (recent-jars [this])
+  (jar-exists [this groupname jarname])
+  (find-jar
+    [this groupname jarname]
+    [this groupname jarname verison])
+  (all-projects [this offset limit])
+  (count-all-projects [this])
+  (count-projects-before [this name])
 
-(defn group-membernames [db groupname]
-  (sql/group-membernames {:groupname groupname}
-                         {:connection db
-                          :row-fn :user}))
-
-(defn group-keys [db groupname]
-  (sql/group-keys {:groupname groupname}
-                  {:connection db
-                   :row-fn :pgp_key}))
-
-(defn jars-by-username [db username]
-  (sql/jars-by-username {:username username}
-                        {:connection db}))
-
-(defn jars-by-groupname [db groupname]
-  (sql/jars-by-groupname {:groupname groupname}
-                         {:connection db}))
-
-(defn recent-versions
-  ([db groupname jarname]
-   (sql/recent-versions {:groupname groupname
-                         :jarname jarname}
-                        {:connection db}))
-  ([db groupname jarname num]
-   (sql/recent-versions-limit {:groupname groupname
-                               :jarname jarname
-                               :num num}
-                              {:connection db})))
-
-(defn count-versions [db groupname jarname]
-  (sql/count-versions {:groupname groupname
-                       :jarname jarname}
-                      {:connection db
-                       :result-set-fn first
-                       :row-fn :count}))
-
-(defn recent-jars [db]
-  (sql/recent-jars {} {:connection db}))
-
-(defn jar-exists [db groupname jarname]
-  (sql/jar-exists {:groupname groupname
-                   :jarname jarname}
-                  {:connection db
-                   :result-set-fn first
-                   :row-fn #(= % 1)}))
-
-(defn find-jar
-  ([db groupname jarname]
-   (sql/find-jar {:groupname groupname
-                  :jarname jarname}
-                 {:connection db
-                  :result-set-fn first}))
-  ([db groupname jarname version]
-   (sql/find-jar-versioned {:groupname groupname
-                            :jarname jarname
-                            :version version}
-                           {:connection db
-                            :result-set-fn first})))
-
-(defn all-projects [db offset-num limit-num]
-  (sql/all-projects {:num limit-num
-                     :offset offset-num}
-                    {:connection db}))
-
-(defn count-all-projects [db]
-  (sql/count-all-projects {}
-                          {:connection db
-                           :result-set-fn first
-                           :row-fn :count}))
-
-(defn count-projects-before [db s]
-  (sql/count-projects-before {:s s}
-                             {:connection db
-                              :result-set-fn first
-                              :row-fn :count}))
-
-(def write-executor (memoize #(Executors/newSingleThreadExecutor)))
-
-(def ^:private ^:dynamic *in-executor* nil)
-
-(defn serialize-task* [task-name task]
-  (if *in-executor*
-    (task)
-    (binding [*in-executor* true]
-      (let [bound-f (bound-fn []
-                      (try
-                        (task)
-                        (catch Throwable e
-                          e)))
-            response (deref
-                      (.submit (write-executor) bound-f)
-                      10000 ::timeout)]
-        (cond
-          (= response ::timeout) (throw
-                                  (ex-info
-                                   "Timed out waiting for serialized task to run"
-                                   {:name task-name}))
-          (instance? Throwable response) (throw
-                                          (ex-info "Serialized task failed"
-                                                   {:name task-name}
-                                                   response))
-          :default response)))))
-
-(defmacro serialize-task [name & body]
-  `(serialize-task* ~name
-                    (fn [] ~@body)))
-
-(defn add-user [db email username password pgp-key time]
-  (let [record {:email email, :username username, :password password,
-                :pgp_key pgp-key :created time}
-        groupname (str "org.clojars." username)]
-    (serialize-task :add-user
-                    (sql/insert-user! record
-                                      {:connection db})
-                    (sql/insert-group! {:groupname groupname :username username}
-                                       {:connection db}))
-    record))
-
-(defn update-user [db account email username password pgp-key]
-  (let [fields {:email email
-                :username username
-                :pgp_key pgp-key
-                :account account
-                :password password}]
-    (serialize-task :update-user
-                    (sql/update-user! fields
-                                      {:connection db}))
-    fields))
-
-(defn update-user-password [db reset-code password]
-  (assert (not (str/blank? reset-code)))
-  (serialize-task :update-user-password
-                    (sql/update-user-password! {:password password
-                                                :reset_code reset-code}
-                                               {:connection db})))
-
-
-(defn set-password-reset-code! [db username-or-email reset-code time]
-  (serialize-task :set-password-reset-code
-                  (sql/set-password-reset-code! {:reset_code reset-code
-                                                 :reset_code_created_at time
-                                                 :username_or_email username-or-email}
-                                                {:connection db})))
-
-(defn add-member [db groupname username added-by]
-  (serialize-task :add-member
-                  (sql/add-member! {:groupname groupname
-                                    :username username
-                                    :added_by added-by}
-                                   {:connection db})))
-
-(defn add-jar [db account {:keys [group name version
-                               description homepage authors]} time]
-  (serialize-task :add-jar
-                  (sql/add-jar! {:groupname group
-                                 :jarname   name
-                                 :version   version
-                                 :user      account
-                                 :created    time
-                                 :description description
-                                 :homepage   homepage
-                                 :authors    authors}
-                                {:connection db})))
-
-(defn delete-jars [db group-id & [jar-id version]]
-  (serialize-task :delete-jars
-                  (let [coords {:group_id group-id}]
-                    (if jar-id
-                      (let [coords (assoc coords :jar_id jar-id)]
-                        (if version
-                          (sql/delete-jar-version! (assoc coords :version version)
-                                                   {:connection db})
-                          (sql/delete-jars! coords
-                                            {:connection db})))
-                      (sql/delete-groups-jars! coords
-                                        {:connection db})))))
-
-;; does not delete jars in the group. should it?
-(defn delete-groups [db group-id]
-  (serialize-task :delete-groups
-                  (sql/delete-group! {:group_id group-id}
-                                     {:connection db})))
-
-(defn find-jars-information
-  ([db group-id]
-   (find-jars-information db group-id nil))
-  ([db group-id artifact-id]
-   (if artifact-id
-     (sql/find-jars-information {:group_id group-id
-                                 :artifact_id artifact-id}
-                                {:connection db})
-     (sql/find-groups-jars-information {:group_id group-id}
-                                       {:connection db}))))
-
-(defn promote [db group name version time]
-  (serialize-task :promote
-                  (sql/promote! {:group_id group
-                                 :artifact_id name
-                                 :version version
-                                 :promoted_at time}
-                                {:connection db})))
-
-(defn promoted? [db group-id artifact-id version]
-  (sql/promoted {:group_id group-id
-                 :artifact_id artifact-id
-                 :version version}
-                {:connection db
-                 :result-set-fn first
-                 :row-fn :promoted_at}))
+  (find-jars-information
+    [this group-id]
+    [this group-id artifact-id])
+  (promote [this group name version time])
+  (promoted? [this group-id artifact-id version])
+  
+  (add-jar [this account {:keys [group name version
+                                 description homepage authors] :as jarmap} time])
+  (delete-jars
+    [this group-id]
+    [this group-id jar-id]
+    [this group-id jar-id version]))

--- a/src/clojars/db/sql.clj
+++ b/src/clojars/db/sql.clj
@@ -1,5 +1,6 @@
 (ns clojars.db.sql
-  (:require [yesql.core :refer [defqueries]]))
+  (:require [yesql.core :refer [defqueries]]
+            [clj-time.jdbc]))
 
 ;; hack due to https://github.com/krisajenkins/yesql/issues/118
 (defqueries "queries/sqlite-queryfile.sql")

--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -1,15 +1,16 @@
-(ns clojars.dev.setup
+(ns ^{:doc "Tools to setup a dev db."}
+  clojars.dev.setup
   "Tools to setup a dev db."
-  (:require [clojars.config :refer [config]]
-            [clojars.db :as db]
-            [clojars.search :as search]
+  (:require [clj-time.core :as time]
+            [clojars
+             [config :refer [config]]
+             [db :as db]
+             [search :as search]]
+            [clojars.db.sql :as sql]
             [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojars.db.sql :as sql])
+            [clojure.string :as str])
   (:import [org.apache.maven.artifact.repository.metadata Metadata Versioning]
-           [org.apache.maven.artifact.repository.metadata.io.xpp3
-            MetadataXpp3Reader
-            MetadataXpp3Writer]))
+           [org.apache.maven.artifact.repository.metadata.io.xpp3 MetadataXpp3Reader MetadataXpp3Writer]))
 
 (defn reset-db! [db]
   (sql/clear-jars! {} {:connection db})
@@ -24,7 +25,7 @@
              (println "User" name "already exists")
              (do
                (printf "Adding user %s/%s\n" name name)
-               (db/add-user db (str name "@example.com") name name "")))
+               (db/add-user db (str name "@example.com") name name "" (time/now))))
            name)
     (range n)))
 
@@ -79,7 +80,8 @@
                             :version version
                             :description (format "Description for %s/%s" group-id artifact-id)
                             :homepage (format "http://example.com/%s/%s" group-id artifact-id)
-                            :authors ["Foo" "Bar" "Basil"]})
+                            :authors "Foo, Bar, Basil"}
+                      (time/now))
           (update-metadata parent group-id artifact-id version)
           [group-id artifact-id version (rand-int 1000)]))
       (remove nil?)

--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -1,9 +1,12 @@
 (ns clojars.friend.registration
   (:require [cemerick.friend :as friend]
             [cemerick.friend.workflows :as workflow]
+            [clj-time.core :as time]
+            [clojars
+             [auth :as auth]
+             [db :refer [add-user]]]
+            [clojars.web.user :refer [new-user-validations register-form]]
             [ring.util.response :refer [response]]
-            [clojars.web.user :refer [register-form new-user-validations]]
-            [clojars.db :refer [add-user]]
             [valip.core :refer [validate]]))
 
 (defn register [db {:keys [email username password confirm pgp-key]}]
@@ -13,7 +16,7 @@
                                    :pgp-key pgp-key}
                          (new-user-validations db confirm))]
     (response (register-form (apply concat (vals errors)) email username))
-    (do (add-user db email username password pgp-key)
+    (do (add-user db email username (auth/bcrypt password) pgp-key (time/now))
         (workflow/make-auth {:identity username :username username}))))
 
 (defn workflow [db]

--- a/src/clojars/maven.clj
+++ b/src/clojars/maven.clj
@@ -1,11 +1,14 @@
 (ns clojars.maven
   (:require [clojure.java.io :as io]
             [clojars.config :refer [config]]
-            [clojure.string :refer [split]]
+            [clojure.string :refer [split join]]
             [clojars.errors :refer [report-error]])
   (:import org.apache.maven.model.io.xpp3.MavenXpp3Reader
            org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader
            java.io.IOException))
+
+(defn collapse-authors [authors]
+  (join ", " (map #(.replace % "," "") authors)))
 
 (defn model-to-map [model]
   {:name (or (.getArtifactId model)
@@ -19,7 +22,7 @@
    :url (.getUrl model)
    :licenses (.getLicenses model)
    :scm (.getScm model)
-   :authors (vec (map #(.getName %) (.getContributors model)))
+   :authors (collapse-authors (map #(.getName %) (.getContributors model)))
    :dependencies (vec (map
                        (fn [d] {:group_name (.getGroupId d)
                                 :jar_name (.getArtifactId d)

--- a/src/clojars/promote.clj
+++ b/src/clojars/promote.clj
@@ -1,20 +1,18 @@
 (ns clojars.promote
-  (:require [clojars.config :refer [config]]
-            [clojars.maven :as maven]
-            [clojars.db :as db]
+  (:require [cemerick.pomegranate.aether :as aether]
+            [clj-pgp
+             [core :as pgp]
+             [signature :as pgp-sig]]
+            [clj-time.core :as time]
+            [clojars
+             [config :refer [config]]
+             [db :as db]
+             [maven :as maven]]
             [clojure.java.io :as io]
-            [clojure.java.shell :as sh]
-            [clojure.java.jdbc :as sql]
-            [clojure.string :as str]
-            [clojure.set :as set]
-            [cemerick.pomegranate.aether :as aether]
-            [clj-pgp.core :as pgp]
-            [clj-pgp.signature :as pgp-sig])
-  (:import (java.util.concurrent LinkedBlockingQueue)
-           (org.springframework.aws.maven SimpleStorageServiceWagon)
-           (java.io File ByteArrayInputStream PrintWriter)
-           (org.bouncycastle.openpgp PGPUtil PGPObjectFactory)
-           (org.bouncycastle.bcpg ArmoredInputStream)))
+            [clojure.string :as str])
+  (:import [java.io ByteArrayInputStream File]
+           [org.bouncycastle.openpgp PGPObjectFactory PGPUtil]
+           org.springframework.aws.maven.SimpleStorageServiceWagon))
 
 (defonce _
   (do (java.security.Security/addProvider
@@ -134,7 +132,7 @@
         (do
           (println "Promoting" info)
           (deploy-to-s3 info)
-          (db/promote db group name version))
+          (db/promote db group name version (time/now)))
         (println "Didn't promote since :releases-url wasn't set."))
       (do (println "...failed.")
           blockers))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -136,4 +136,4 @@
        (wrap-exceptions reporter))))
 
 (defn handler-optioned [{:keys [db error-reporter] :as opts}]
-  (clojars-app (:spec db) error-reporter))
+  (clojars-app db error-reporter))

--- a/src/clojars/web/browse.clj
+++ b/src/clojars/web/browse.clj
@@ -2,10 +2,18 @@
   (:require [clojars.web.common :refer [html-doc jar-link user-link format-date
                                         page-nav page-description jar-name
                                         collection-fork-notice]]
-            [clojars.db :refer [browse-projects count-all-projects
+            [clojars.db :refer [find-jar all-projects count-all-projects
                                 count-projects-before]]
             [hiccup.form :refer [label submit-button text-field submit-button]]
             [ring.util.response :refer [redirect]]))
+
+(defn browse-projects [db current-page per-page]
+  (vec
+   (map
+    #(find-jar db (:group_name %) (:jar_name %))
+    (all-projects db
+                  (* (dec current-page) per-page)
+                  per-page))))
 
 (defn browse-page [db account page per-page]
   (let [project-count (count-all-projects db)

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -110,7 +110,7 @@
                            (update-user-validations confirm))]
       (profile-form account params nil (apply concat (vals errors)))
       (let [password (if (empty? password)
-                       (:password (db/find-user account))
+                       (:password (db/find-user db account))
                        (bcrypt password))]
         (do (update-user db account email account password pgp-key)
             (assoc (redirect "/profile")

--- a/test/clojars/test/integration/api.clj
+++ b/test/clojars/test/integration/api.clj
@@ -11,7 +11,6 @@
 
 (use-fixtures :each
   help/default-fixture
-  help/with-clean-database
   help/run-test-app)
 
 (defn get-api [parts & [opts]]

--- a/test/clojars/test/integration/sessions.clj
+++ b/test/clojars/test/integration/sessions.clj
@@ -44,7 +44,7 @@
   (let [app (help/app)]
     (-> (session app)
         (register-as "fixture" "fixture@example.org" "password"))
-    (jdbc/db-do-commands help/*db*
+    (jdbc/db-do-commands (:db help/*db*)
                          "update users set password='' where user = 'fixture'")
     (-> (session app)
         (login-as "fixture" "password")

--- a/test/clojars/test/integration/uploads.clj
+++ b/test/clojars/test/integration/uploads.clj
@@ -16,7 +16,6 @@
 (use-fixtures :each
   help/default-fixture
   help/index-fixture
-  help/with-clean-database
   help/run-test-app)
 
 (deftest user-can-register-and-deploy

--- a/test/clojars/test/integration/web.clj
+++ b/test/clojars/test/integration/web.clj
@@ -1,11 +1,12 @@
-(ns clojars.test.integration.web
-  (:require [clojure.test :refer :all]
-            [kerodon.core :refer :all]
-            [kerodon.test :refer :all]
-            [clojars.test.integration.steps :refer :all]
-            [clojars.web :as web]
+(ns ^{:clojure.test/each-fixtures (#object[clojars.test.test_helper$default_fixture 0x37ce12ec "clojars.test.test_helper$default_fixture@37ce12ec"] #object[clojars.test.test_helper$with_clean_database 0x74123c9b "clojars.test.test_helper$with_clean_database@74123c9b"])}
+  clojars.test.integration.web
+  (:require [clj-time.core :as time]
             [clojars.db :as db]
             [clojars.test.test-helper :as help]
+            [clojure.test :refer :all]
+            [kerodon
+             [core :refer :all]
+             [test :refer :all]]
             [net.cgrand.enlive-html :as enlive]))
 
 (use-fixtures :each
@@ -37,7 +38,8 @@
     (db/add-jar
      help/*db*
       "test-user"
-      {:name (str "tester" i) :group "tester" :version "0.1" :description "Huh" :authors ["Zz"]}))
+      {:name (str "tester" i) :group "tester" :version "0.1" :description "Huh" :authors ["Zz"]}
+      (time/epoch)))
    (-> (session (help/app))
      (visit "/projects")
      (within [:div.light-article :> :h1]
@@ -62,7 +64,8 @@
     (db/add-jar
      help/*db*
       "test-user"
-      {:name (str "tester" i "a") :group "tester" :version "0.1" :description "Huh" :authors ["Zz"]}))
+      {:name (str "tester" i "a") :group "tester" :version "0.1" :description "Huh" :authors ["Zz"]}
+      (time/epoch)))
   (-> (session (help/app))
       (visit "/projects")
       (fill-in "Enter a few letters..." "tester/tester123")

--- a/test/clojars/test/integration/web.clj
+++ b/test/clojars/test/integration/web.clj
@@ -1,5 +1,4 @@
-(ns ^{:clojure.test/each-fixtures (#object[clojars.test.test_helper$default_fixture 0x37ce12ec "clojars.test.test_helper$default_fixture@37ce12ec"] #object[clojars.test.test_helper$with_clean_database 0x74123c9b "clojars.test.test_helper$with_clean_database@74123c9b"])}
-  clojars.test.integration.web
+(ns clojars.test.integration.web
   (:require [clj-time.core :as time]
             [clojars.db :as db]
             [clojars.test.test-helper :as help]

--- a/test/clojars/test/unit/promote.clj
+++ b/test/clojars/test/unit/promote.clj
@@ -1,11 +1,12 @@
 (ns clojars.test.unit.promote
-  (:require [clojure.test :refer :all]
-            [clojars.promote :refer :all]
+  (:require [clj-time.core :as time]
+            [clojars
+             [config :refer [config]]
+             [db :as db]
+             [promote :refer :all]]
+            [clojars.test.test-helper :as help]
             [clojure.java.io :as io]
-            [clojars.maven :as maven]
-            [clojars.db :as db]
-            [clojars.config :refer [config]]
-            [clojars.test.test-helper :as help]))
+            [clojure.test :refer :all]))
 
 (use-fixtures :each
   help/default-fixture
@@ -45,7 +46,8 @@
   (copy-resource "1.1.2" "jar.asc")
   (copy-resource "1.1.2" "pom.asc")
   (db/add-user help/*db* "test@ex.com" "testuser" "password"
-               (slurp (io/resource "pubring.gpg")))
+               (slurp (io/resource "pubring.gpg"))
+               (time/epoch))
   (db/add-member help/*db* "robert" "testuser" nil)
   (is (empty? (blockers help/*db*
                         {:group "robert" :name "hooke" :version "1.1.2"}))))
@@ -57,7 +59,8 @@
   (copy-resource "1.1.2" "jar.asc")
   (copy-resource "1.1.2" "pom.asc")
   (db/add-user help/*db* "test@ex.com" "testuser" "password"
-               (slurp (io/resource "pubring.gpg")))
+               (slurp (io/resource "pubring.gpg"))
+               (time/epoch))
   (db/add-member help/*db* "robert" "testuser" nil)
   (is (= [(str "Could not verify signature of "
                (config :repo) "/robert/hooke/1.1.2/hooke-1.1.2.jar. "
@@ -71,7 +74,7 @@
            (file-for "robert" "hooke" "1.1.2" "jar"))
   (copy-resource "1.1.2" "jar.asc")
   (copy-resource "1.1.2" "pom.asc")
-  (db/add-user help/*db* "test@ex.com" "testuser" "password" "")
+  (db/add-user help/*db* "test@ex.com" "testuser" "password" "" (time/epoch))
   (db/add-member help/*db* "robert" "testuser" nil)
   (is (= [(str "Could not verify signature of "
                (config :repo) "/robert/hooke/1.1.2/hooke-1.1.2.jar. "

--- a/test/clojars/test/unit/routes/api.clj
+++ b/test/clojars/test/unit/routes/api.clj
@@ -1,9 +1,8 @@
 (ns clojars.test.unit.routes.api
-  (:require [clojars.db :as db]
-            [clojure.java.jdbc :as jdbc]
+  (:require [clj-time.core :as time]
+            [clojars.db :as db]
             [clojars.test.test-helper :as help]
-            [clojure.test :refer :all]
-            [clojars.routes.api :as api]))
+            [clojure.test :refer :all]))
 
 (use-fixtures :each
   help/default-fixture
@@ -14,8 +13,8 @@
 (def jarmap {:name jarname :group jarname})
 
 (defn add-jar [i version & {:as override}]
-  (with-redefs [db/get-time (fn [] (java.sql.Timestamp. i))]
-    (is (db/add-jar help/*db* "test-user" (merge (assoc jarmap :version version) override)))))
+  (is (db/add-jar help/*db* "test-user" (merge (assoc jarmap :version version) override)
+                  (time/plus (time/epoch) (time/seconds i)))))
 
 
 (deftest only-release

--- a/test/clojars/test/unit/routes/repo.clj
+++ b/test/clojars/test/unit/routes/repo.clj
@@ -1,0 +1,37 @@
+(ns clojars.test.unit.routes.repo
+    (:require [clojure.test :refer :all]
+              [clojars.routes.repo :refer :all]
+              [clojars.db :as db]
+              [clojars.test.test-helper :as help]))
+
+(deftest check-group-validates-group-name-format
+  (is (thrown? Exception (check-group nil "test-user" nil)))
+  (is (thrown? Exception (check-group nil "test-user" "")))
+  (is (thrown? Exception (check-group nil "test-user" "HI")))
+  (is (thrown? Exception (check-group nil "test-user" "lein*")))
+  (is (thrown? Exception (check-group nil "test-user" "lein=")))
+  (is (thrown? Exception (check-group nil "test-user" "lein>")))
+  (is (thrown? Exception (check-group nil "test-user" "べ")))
+  (help/with-clean-database
+    (fn []
+      (is (check-group help/*db* "test-user" "hi"))
+      (is (check-group help/*db* "test-user" "hi-"))
+      (is (check-group help/*db* "test-user" "hi_1...2")))))
+
+(deftest check-group-validates-group-name-is-not-reserved
+  (doseq [group reserved-names]
+    (is (thrown? Exception (check-group nil "test-user" group)))))
+
+(deftest check-group-validates-group-permissions
+  (help/with-clean-database
+    (fn []
+      (db/add-member help/*db* "group-name" "some-user" "some-dude")
+      (is (thrown? Exception (check-group help/*db* "test-user" "group-name"))))))
+
+(deftest check-group-creates-single-member-group-for-user
+  (help/with-clean-database
+    (fn []
+      (check-group help/*db* "test-user" "group-name")
+      (is (= ["test-user"] (db/group-membernames help/*db* "group-name")))
+      (is (= ["group-name"]
+             (db/find-groupnames help/*db* "test-user"))))))

--- a/test/clojars/test/unit/web/browse.clj
+++ b/test/clojars/test/unit/web/browse.clj
@@ -1,0 +1,38 @@
+(ns clojars.test.unit.web.browse
+  (:require [clj-time.core :as time]
+            [clojars.db :as db]
+            [clojars.test.test-helper :as help]
+            [clojars.web.browse :refer :all]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each
+  help/using-test-config
+  help/with-clean-database)
+
+(deftest browse-projects-finds-jars
+  (db/add-jar help/*db* "test-user" {:name "rock" :group "jester" :version "0.1"}
+              (time/epoch))
+  (db/add-jar help/*db* "test-user" {:name "rock" :group "tester" :version "0.1"}
+              (time/epoch))
+  (db/add-jar help/*db* "test-user" {:name "rock" :group "tester" :version "0.2"}
+              (time/plus (time/epoch) (time/seconds 1)))
+  (db/add-jar help/*db* "test-user" {:name "paper" :group "tester" :version "0.1"}
+              (time/plus (time/epoch) (time/seconds 1)))
+  (db/add-jar help/*db* "test-user" {:name "scissors" :group "tester" :version "0.1"}
+              (time/plus (time/epoch) (time/seconds 2)))
+    ; tests group_name and jar_name ordering
+    (is (=
+          '({:version "0.1", :jar_name "rock", :group_name "jester"}
+            {:version "0.1", :jar_name "paper", :group_name "tester"})
+          (->>
+            (browse-projects help/*db* 1 2)
+            (map #(select-keys % [:group_name :jar_name :version])))))
+
+    ; tests version ordering and pagination
+    (is (=
+          '({:version "0.2", :jar_name "rock", :group_name "tester"}
+            {:version "0.1", :jar_name "scissors", :group_name "tester"})
+          (->>
+            (browse-projects help/*db* 2 2)
+            ( map #(select-keys % [:group_name :jar_name :version]))))))
+


### PR DESCRIPTION
Lets make a protocol for the database. This allows us to not care about the internal details of the connection pool in dev/prod vs a normal connection in test. This also allows the thread executor to stop being a global. However we need to make the database functions into a protocol. Moving logic out of the database component and into the call sites also makes this code simpler.

Future work could include having a fake database for testing and making the database protocol be several with single responsibilities.
