### PR TITLE
Thread object for stats lookup and use a protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 sudo: false
 language: clojure
 lein: lein2
+jdk:
+  - oraclejdk8

--- a/project.clj
+++ b/project.clj
@@ -62,6 +62,7 @@
                                   [eftest "0.1.0"]
                                   [kerodon "0.7.0"
                                    :exclusions [org.apache.httpcomponents/httpcore]]
-                                  [clj-http-lite "0.3.0"]]
+                                  [clj-http-lite "0.3.0"]
+                                  [com.google.jimfs/jimfs 1.0]]
                    :resource-paths ["local-resources"]}
    :project/test  {}})

--- a/src/clojars/dev/setup.clj
+++ b/src/clojars/dev/setup.clj
@@ -62,6 +62,9 @@
   [db repo stats-dir users]
   (let [group-artifact-pattern (re-pattern (str repo "/(.*)/([^/]*)$"))
         stats-file (io/file stats-dir "all.edn")]
+    (let [d (io/file stats-dir)]
+      (when-not (.exists d)
+        (.mkdirs d)))
     (->>
       (for [version-dir (file-seq (io/file repo))
             :when (and (.isDirectory version-dir)

--- a/src/clojars/routes/api.clj
+++ b/src/clojars/routes/api.clj
@@ -8,10 +8,9 @@
             [ring.middleware.format-response :refer [wrap-restful-response]]
             [ring.util.response :refer [response]]))
 
-(defn get-artifact [db group-id artifact-id]
+(defn get-artifact [db stats group-id artifact-id]
   (if-let [artifact (first (db/find-jars-information db group-id artifact-id))]
-    (let [stats (stats/all)]
-      (-> artifact
+    (-> artifact
         (assoc
           :recent_versions (db/recent-versions db group-id artifact-id)
           :downloads (stats/download-count stats group-id artifact-id))
@@ -21,25 +20,24 @@
                    (assoc version
                      :downloads (stats/download-count stats group-id artifact-id (:version version))))
               versions)))
-        response))
+        response)
     (not-found nil)))
 
-(defn handler [db]
+(defn handler [db stats]
   (compojure/routes
    (context "/api" []
             (GET ["/groups/:group-id", :group-id #"[^/]+"] [group-id]
                  (if-let [jars (seq (db/find-jars-information db group-id))]
-                   (let [stats (stats/all)]
-                     (response
-                      (map (fn [jar]
-                             (assoc jar
-                                    :downloads (stats/download-count stats group-id (:jar_name jar))))
-                           jars)))
+                   (response
+                    (map (fn [jar]
+                           (assoc jar
+                                  :downloads (stats/download-count stats group-id (:jar_name jar))))
+                         jars))
                    (not-found nil)))
             (GET ["/artifacts/:artifact-id", :artifact-id #"[^/]+"] [artifact-id]
-                 (get-artifact db artifact-id artifact-id))
+                 (get-artifact db stats artifact-id artifact-id))
             (GET ["/artifacts/:group-id/:artifact-id", :group-id #"[^/]+", :artifact-id #"[^/]+"] [group-id artifact-id]
-                 (get-artifact db group-id artifact-id))
+                 (get-artifact db stats group-id artifact-id))
             (GET "/users/:username" [username]
                  (if-let [groups (seq (db/find-groupnames db username))]
                    (response {:groups groups})
@@ -47,6 +45,6 @@
             (ANY "*" _
                  (not-found nil)))))
 
-(defn routes [db]
-  (-> (handler db)
+(defn routes [db stats]
+  (-> (handler db stats)
       (wrap-restful-response :formats [:json :edn :yaml :transit-json])))

--- a/src/clojars/stats.clj
+++ b/src/clojars/stats.clj
@@ -1,29 +1,62 @@
 (ns clojars.stats
-  (:require [clojars.config :as config]
-            [clojure.java.io :as io]
-            [clojure.core.memoize :as memo]))
+  (:require [clojure.core.memoize :as memo]
+            [com.stuartsierra.component :as component])
+  (:import java.nio.file.Files
+           java.nio.file.LinkOption))
 
-(defn all* []
-  (let [path (str (config/config :stats-dir) "/all.edn")]
-    (if (.exists (io/as-file path))
-      (read (java.io.PushbackReader. (java.io.FileReader.
-                                      (str (config/config :stats-dir)
-                                           "/all.edn"))))
-      {})))
+(defprotocol Stats
+  (download-count
+    [t group-id artifact-id]
+    [t group-id artifact-id version])
+  (total-downloads [t]))
+
+(defrecord MapStats [s]
+  Stats
+  (download-count [t group-id artifact-id]
+     (->> (s [group-id artifact-id])
+          vals
+          (apply +)))
+  (download-count [t group-id artifact-id version]
+    (get-in s [[group-id artifact-id] version] 0))
+  (total-downloads [t]
+    (apply + (mapcat vals (vals s)))))
+
+(defn all* [path]
+  (->MapStats (if (Files/exists path (make-array LinkOption 0))
+                (read (java.io.PushbackReader. (Files/newBufferedReader path)))
+                {})))
 
 (def all (memo/ttl all* :ttl/threshold (* 60 60 1000))) ;; 1 hour
 
-(defn download-count [dls group-id artifact-id & [version]]
-  (let [ds (dls [group-id artifact-id])]
-    (or (if version
-          (get ds version)
-          (->> ds
-               (map second)
-               (apply +)))
-        0)))
+(defrecord FileStats [fs-factory path-factory fs path]
+  Stats
+  (download-count [t group-id artifact-id]
+    (download-count (all path) group-id artifact-id))
+  (download-count [t group-id artifact-id version-id]
+    (download-count (all path) group-id artifact-id version-id))
+  (total-downloads [t]
+    (total-downloads (all path)))
+  component/Lifecycle
+  (start [t]
+    (if fs
+      t
+      (let [fs (fs-factory)]
+        (assoc t
+               :fs fs
+               :path (path-factory fs)))))
+  (stop [t]
+    (when fs
+      (try
+        (.close fs)
+        (catch UnsupportedOperationException _
+          ;; java says we should close these, but then defines
+          ;; closing the default one to be an error :/
+          )))
+    (assoc t
+           :fs nil
+           :path nil)))
 
-(defn total-downloads [dls]
-  (apply +
-         (for [[[g a] vs] dls
-               [v c] vs]
-           c)))
+(defn file-stats [stats-dir]
+  (map->FileStats {:path-factory #(.getPath %
+                                            (str stats-dir "/all.edn")
+                                            (make-array String 0))}))

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -1,6 +1,7 @@
 (ns clojars.system
   (:require [clojars
              [ring-servlet-patch :as patch]
+             [stats :refer [file-stats]]
              [web :as web]]
             [com.stuartsierra.component :as component]
             [duct.component
@@ -8,7 +9,8 @@
              [handler :refer [handler-component]]
              [hikaricp :refer [hikaricp]]]
             [meta-merge.core :refer [meta-merge]]
-            [ring.component.jetty :refer [jetty-server]]))
+            [ring.component.jetty :refer [jetty-server]])
+  (:import java.nio.file.FileSystems))
 
 (def base-env
   {:app {:middleware []}
@@ -34,8 +36,11 @@
          :app  (handler-component (:app config))
          :http (jetty-server (:http config))
          :db   (hikaricp (:db config))
+         :fs-factory #(FileSystems/getDefault)
+         :stats (file-stats (:stats-dir config))
          :clojars-app   (endpoint-component web/handler-optioned))
         (component/system-using
          {:http [:app]
           :app  [:clojars-app]
-          :clojars-app [:db :error-reporter]}))))
+          :stats [:fs-factory]
+          :clojars-app [:db :error-reporter :stats]}))))

--- a/src/clojars/web/dashboard.clj
+++ b/src/clojars/web/dashboard.clj
@@ -4,9 +4,8 @@
             [clojars.stats :as stats]
             [hiccup.element :refer [unordered-list link-to]]))
 
-(defn recent-jar [jar-map]
-  (let [stats (stats/all)
-        description (:description jar-map)
+(defn recent-jar [stats jar-map]
+  (let [description (:description jar-map)
         truncate-length 120]
     [:li.col-md-4.col-sm-6.col-xs-12.col-lg-4
      [:div.recent-jar
@@ -20,7 +19,7 @@
                                                                    (:group_name jar-map)
                                                                    (:jar_name jar-map))]]]))
 
-(defn index-page [db account]
+(defn index-page [db stats account]
   (html-doc-with-large-header account nil
     [:article.row
      [:div.push-information.col-md-6.col-lg-6.col-sm-6.col-xs-12
@@ -39,7 +38,7 @@
     [:div.recent-jars-header-container.row
      [:h2.recent-jars-header.col-md-12.col-lg-12.col-sm-12.col-xs-12
       "Recently pushed projects"]]
-    [:ul.recent-jars-list.row (map recent-jar (recent-jars db))]))
+    [:ul.recent-jars-list.row (map #(recent-jar stats %) (recent-jars db))]))
 
 (defn dashboard [db account]
   (html-doc account "Dashboard"

--- a/src/clojars/web/jar.clj
+++ b/src/clojars/web/jar.clj
@@ -82,35 +82,34 @@
                                    "/promote/" (:version jar))]
                        (submit-button "Promote")))))))
 
-(defn show-jar [db reporter account jar recent-versions count]
+(defn show-jar [db reporter stats account jar recent-versions count]
   (html-doc account (str (:jar_name jar) " " (:version jar))
             (let [pom-map (jar-to-pom-map reporter jar)]
               [:div.light-article.row
                [:div#jar-title.col-sm-9.col-lg-9.col-xs-12.col-md-9
                 [:h1 (jar-link jar)]
                 [:p.description (:description jar)]
-                (let [stats (stats/all)]
-                  [:ul#jar-info-bar.row
-                   [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
-                    (if-let [gh-info (github-info pom-map)]
-                      (link-to {:target "_blank"}
-                               (format "https://github.com/%s" gh-info)
-                               (image "/images/GitHub-Mark-16px.png" "GitHub")
-                               gh-info)
-                      [:p.github
-                       (image "/images/GitHub-Mark-16px.png" "GitHub")
-                       "N/A"])]
-                   [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
-                    (stats/download-count stats
-                                              (:group_name jar)
-                                              (:jar_name jar))
-                    " Downloads"]
-                   [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
-                    (stats/download-count stats
-                                              (:group_name jar)
-                                              (:jar_name jar)
-                                              (:version jar))
-                    " This Version"]])
+                [:ul#jar-info-bar.row
+                 [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
+                  (if-let [gh-info (github-info pom-map)]
+                    (link-to {:target "_blank"}
+                             (format "https://github.com/%s" gh-info)
+                             (image "/images/GitHub-Mark-16px.png" "GitHub")
+                             gh-info)
+                    [:p.github
+                     (image "/images/GitHub-Mark-16px.png" "GitHub")
+                     "N/A"])]
+                 [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
+                  (stats/download-count stats
+                                        (:group_name jar)
+                                        (:jar_name jar))
+                  " Downloads"]
+                 [:li.col-md-4.col-sm-4.col-xs-12.col-lg-4
+                  (stats/download-count stats
+                                        (:group_name jar)
+                                        (:jar_name jar)
+                                        (:version jar))
+                  " This Version"]]
                 (when-not pom-map
                   [:p.error "Oops. We hit an error opening the metadata POM file for this project "
                    "so some details are not available."])

--- a/src/clojars/web/search.clj
+++ b/src/clojars/web/search.clj
@@ -15,22 +15,22 @@
       (assoc m :created created)
       m)))
 
-(defn json-gen [query]
-  (let [results (search/search query)]
+(defn json-gen [stats query]
+  (let [results (search/search stats query)]
     (json/generate-string {:count (count results)
                            :results (map jar->json results)})))
 
-(defn json-search [query]
+(defn json-search [stats query]
   {:status 200,
    :headers {"Content-Type" "application/json; charset=UTF-8"}
-   :body (json-gen query)})
+   :body (json-gen stats query)})
 
-(defn html-search [account query page]
+(defn html-search [stats account query page]
   (html-doc account (str query " - search")
     [:div.light-article.row
      [:h1 "Search for '" query "'"]
      (try
-       (let [results (search/search query :page page)
+       (let [results (search/search stats query :page page)
              {:keys [total-hits results-per-page offset]} (meta results)]
          (if (empty? results)
            [:p "No results."]
@@ -57,9 +57,9 @@
        (catch Exception _
          [:p "Could not search; please check your query syntax."]))]))
 
-(defn search [account params]
+(defn search [stats account params]
   (let [q (params :q)
         page (or (params :page) 1)]
     (if (= (params :format) "json")
-      (json-search q)
-      (html-search account q page))))
+      (json-search stats q)
+      (html-search stats account q page))))

--- a/test/clojars/test/unit/search.clj
+++ b/test/clojars/test/unit/search.clj
@@ -1,28 +1,33 @@
 (ns clojars.test.unit.search
-  (:require [clojars.search :as search]
-            [clojure.test :refer :all]
-            [clojars.test.test-helper :as help]))
+  (:require [clojars
+             [search :as search]
+             [stats :as stats]]
+            [clojars.test.test-helper :as help]
+            [clojure.test :refer :all]))
 
 (use-fixtures :each help/default-fixture)
 
 (deftest weight-by-downloads
-  (help/make-download-count! {["lein-ring" "lein-ring"] {"0.0.1" 10000}
-                              ["lein-modules" "lein-modules"] {"0.1.0" 200}
-                              ["c" "c"] {"0.1.0" 100000}})
   (help/make-index! [{:artifact-id "lein-ring"
                       :group-id "lein-ring"}
                      {:artifact-id "lein-modules"
                       :group-id "lein-modules"}
                      {:artifact-id "c"
                       :group-id "c"}])
-  (is (= (search/search "lein-modules")
-         [{:group-id "lein-modules", :artifact-id "lein-modules"}
-          {:group-id "lein-ring", :artifact-id "lein-ring"}]))
-  (is (= (search/search "lein-ring")
-         [{:group-id "lein-ring", :artifact-id "lein-ring"}
-          {:group-id "lein-modules", :artifact-id "lein-modules"}]))
-  (is (= (search/search "lein")
-         [{:group-id "lein-ring", :artifact-id "lein-ring"}
-          {:group-id "lein-modules", :artifact-id "lein-modules"}]))
-  (is (= (search/search "ring")
-         [{:group-id "lein-ring", :artifact-id "lein-ring"}])))
+  (let [stats (reify stats/Stats
+                (download-count [t g a]
+                  ({["lein-ring" "lein-ring"] 2
+                    ["lein-modules" "lein-modules"] 1}
+                   [g a]))
+                (total-downloads [t] 100))]
+    (is (= (search/search stats "lein-modules")
+           [{:group-id "lein-modules", :artifact-id "lein-modules"}
+            {:group-id "lein-ring", :artifact-id "lein-ring"}]))
+    (is (= (search/search stats "lein-ring")
+           [{:group-id "lein-ring", :artifact-id "lein-ring"}
+            {:group-id "lein-modules", :artifact-id "lein-modules"}]))
+    (is (= (search/search stats "lein")
+           [{:group-id "lein-ring", :artifact-id "lein-ring"}
+            {:group-id "lein-modules", :artifact-id "lein-modules"}]))
+    (is (= (search/search stats "ring")
+           [{:group-id "lein-ring", :artifact-id "lein-ring"}]))))

--- a/test/clojars/test/unit/stats.clj
+++ b/test/clojars/test/unit/stats.clj
@@ -1,0 +1,65 @@
+(ns clojars.test.unit.stats
+  (:require [clojars.stats :refer :all]
+            [clojure.test :refer :all]
+            [com.stuartsierra.component :as component])
+  (:import com.google.common.jimfs.Jimfs
+           com.google.common.jimfs.Configuration
+           java.nio.file.Files
+           java.nio.file.OpenOption
+           java.nio.file.attribute.FileAttribute))
+
+(def download-counts {["a" "x"] {"1" 1
+                                 "2" 2}
+                      ["b" "y"] {"1" 4}
+                      ["c" "z"] {"1" 5}})
+
+(deftest map-stats-computes-group-downloads
+  (let [stats (->MapStats download-counts)]
+    (is (= 3 (download-count stats "a" "x")))
+    (is (= 4 (download-count stats "b" "y")))
+    (is (= 5 (download-count stats "c" "z")))))
+
+(deftest map-stats-looks-up-version-downloads
+  (let [stats (->MapStats download-counts)]
+    (is (= 1 (download-count stats "a" "x" "1")))
+    (is (= 2 (download-count stats "a" "x" "2")))
+    (is (= 4 (download-count stats "b" "y" "1")))
+    (is (= 5 (download-count stats "c" "z" "1")))))
+
+(deftest map-stats-returns-zero-for-missing-values
+  (let [stats (->MapStats download-counts)]
+    (is (= 0 (download-count stats "a" "y" "1")))
+    (is (= 0 (download-count stats "a" "x" "3")))
+    (is (= 0 (download-count stats "d" "d" "1")))))
+
+(defn fs-with-stats-file [dir string]
+  (let [fs (Jimfs/newFileSystem (Configuration/unix))]
+    (Files/createDirectory (.getPath fs dir (make-array String 0))
+                           (make-array FileAttribute 0))
+    (Files/write (.getPath fs dir (into-array String ["all.edn"]))
+                 (.getBytes string)             
+                 (make-array OpenOption 0))
+    fs))
+
+(deftest file-stats-uses-file
+  (let [stats (component/start (assoc (file-stats "some-dir")
+                                      :fs-factory #(fs-with-stats-file "some-dir"
+                                                                       (pr-str download-counts))))]
+    (try
+      (is (= 5 (download-count stats "c" "z")))
+      (finally
+        (component/stop stats)))))
+
+(deftest file-stats-memoizes-file-reading
+  (let [stats (component/start (assoc (file-stats "some-dir")
+                                      :fs-factory #(fs-with-stats-file "some-dir"
+                                                                       (pr-str download-counts))))]
+    (try
+      (download-count stats "c" "z")
+      (Files/write (.getPath (:fs stats) "some-dir" (into-array String ["all.edn"]))
+                   (.getBytes (pr-str {["c" "z"] {"1" 722}}))
+                   (make-array OpenOption 0))
+      (is (= 5 (download-count stats "c" "z")))
+      ;; TODO test cache expiration
+      (finally
+        (component/stop stats)))))

--- a/test/clojars/test/unit/web/jar.clj
+++ b/test/clojars/test/unit/web/jar.clj
@@ -10,21 +10,27 @@
 (deftest bad-homepage-url-shows-as-text
   (let [html (jar/show-jar help/*db*
                            (help/quiet-reporter)
-                           nil {:homepage "something thats not a url"
-                                :created 3
-                                :version "1"
-                                :group_name "test"
-                                :jar_name "test"}
-                           [] 0)]
+                           (help/no-stats)
+                           nil
+                           {:homepage "something thats not a url"
+                            :created 3
+                            :version "1"
+                            :group_name "test"
+                            :jar_name "test"}
+                           []
+                           0)]
     (is (re-find #"something thats not a url" html))))
 
 (deftest pages-are-escaped
   (let [html (jar/show-jar help/*db*
                            (help/quiet-reporter)
-                           nil {:homepage nil
-                                :created 3
-                                :version "<script>alert('hi')</script>"
-                                :group_name "test"
-                                :jar_name "test"}
-                           [] 0)]
+                           (help/no-stats)
+                           nil
+                           {:homepage nil
+                            :created 3
+                            :version "<script>alert('hi')</script>"
+                            :group_name "test"
+                            :jar_name "test"}
+                           []
+                           0)]
     (is (not (.contains html "<script>alert('hi')</script>")))))


### PR DESCRIPTION
This allows different implementations based on usage:

1. FileStat for dev and production system. This one reads a
file (memoized!) just like previously. It takes a filesystem factory,
so that unit tests can be created for it that use an in memory filesystem.

2. MapStat for in memory version. This is delegated to for computation
by FileStat. It is also used in the tests to provide 0 downloads without
having to touch a filesystem.

3. A reified stub used for unit testing search.