### PR TITLE
added defaultCharset to newBufferedReader

### DIFF
--- a/src/clojars/stats.clj
+++ b/src/clojars/stats.clj
@@ -2,7 +2,8 @@
   (:require [clojure.core.memoize :as memo]
             [com.stuartsierra.component :as component])
   (:import java.nio.file.Files
-           java.nio.file.LinkOption))
+           java.nio.file.LinkOption
+           java.nio.charset.Charset))
 
 (defprotocol Stats
   (download-count
@@ -23,7 +24,7 @@
 
 (defn all* [path]
   (->MapStats (if (Files/exists path (make-array LinkOption 0))
-                (read (java.io.PushbackReader. (Files/newBufferedReader path)))
+                (read (java.io.PushbackReader. (Files/newBufferedReader path (Charset/defaultCharset))))
                 {})))
 
 (def all (memo/ttl all* :ttl/threshold (* 60 60 1000))) ;; 1 hour


### PR DESCRIPTION
I couldn't get this to boot, looks like newBufferedReader expects a Charset, which I obligingly added.  All tests pass but hard to ensure stats work w/o an upload test.  Trivial change, probably works great.