### PR TITLE
Exclude xml-apis license/ dir from uberjar

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -24,7 +24,11 @@
   (b/uber {:class-dir class-dir
            :uber-file uber-file
            :basis basis
-           :main 'clojars.main}))
+           :main 'clojars.main
+           ;; xml-apis ships a `license/` directory that collides with a
+           ;; top-level `LICENSE` file from another lib on case-insensitive
+           ;; filesystems (e.g. default macOS).
+           :exclude ["^license/.*"]}))
 
 (defn tag-release [_]
   (let [version (format "%s.%s" (LocalDate/now) (b/git-count-revs nil))]


### PR DESCRIPTION
## Summary
- `make uberjar` fails on case-insensitive filesystems (e.g. default macOS) because `xml-apis` ships a `license/` directory whose entries collide with a top-level `LICENSE` file from another dep.
- Error: `Cannot write license/LICENSE.dom-documentation.txt from xml-apis/xml-apis as parent dir is a file from another lib.`
- Adds a minimal `:exclude ["^license/.*"]` to the `b/uber` call so the xml-apis license docs are dropped from the uberjar.

## Test plan
- [x] `make uberjar` succeeds locally on macOS (case-insensitive APFS)
- [x] `make test` passes (264 tests, 1160 assertions, 0 failures)