### PR TITLE
Invalidate other sessions when the password changes

### DIFF
--- a/src/clojars/http_utils.clj
+++ b/src/clojars/http_utils.clj
@@ -25,6 +25,45 @@
   []
   (reset! session-store-atom {}))
 
+(defn- ring-session-from-store-entry
+  "The aging-session store maps session keys to `SessionEntry` records (or
+  equivalent maps) holding the Ring session map under `:value`."
+  [entry]
+  (:value entry))
+
+(defn- session-username
+  "Returns the Clojars username for a Ring session authenticated via Friend,
+  or nil if unauthenticated.
+
+  Friend 0.2.x stores `::identity` as `{:authentications {id auth-map ...}
+  :current id}`. Some tests use a flat `{:username ...}` map for convenience."
+  [ring-session]
+  (let [friend-id (:cemerick.friend/identity ring-session)]
+    (when friend-id
+      (cond
+        (string? friend-id) friend-id
+        (and (map? friend-id) (:authentications friend-id) (:current friend-id))
+        (:username (get (:authentications friend-id) (:current friend-id)))
+        (map? friend-id) (:username friend-id)))))
+
+(defn clear-sessions-for-user!
+  "Removes all server-side sessions whose Friend identity is `username`.
+  When `keep-session-key` is provided (the Ring `:session/key` for the current
+  request), that session is retained so the browser that performed a profile
+  password change stays signed in."
+  [username & {:keys [keep-session-key]}]
+  (swap! session-store-atom
+         (fn [sessions]
+           (reduce-kv
+            (fn [m k entry]
+              (let [ring-session (ring-session-from-store-entry entry)
+                    auth-user (session-username ring-session)]
+                (if (and auth-user (= auth-user username) (not= k keep-session-key))
+                  m
+                  (assoc m k entry))))
+            {}
+            sessions))))
+
 (defn wrap-secure-session [f]
   (let [mem-store (aging-session/aging-memory-store
                    :session-atom     session-store-atom

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -123,7 +123,8 @@
           #(view/profile-form % (db/find-user db %) flash)))
    (POST "/profile" {:as request :keys [params]}
          (auth/with-account
-           #(view/update-profile db event-emitter % params (common/request-details request))))
+           #(view/update-profile db event-emitter % params (common/request-details request)
+                                 (:session/key request))))
 
    (GET "/mfa" {:keys [flash]}
         (auth/with-account

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -9,6 +9,7 @@
                               update-user
                               update-user-notifications]]
    [clojars.event :as event]
+   [clojars.http-utils :as http-utils]
    [clojars.hcaptcha :as hcaptcha]
    [clojars.log :as log]
    [clojars.notifications.common :as notif-common]
@@ -100,7 +101,8 @@
     (str/lower-case (str/trim email))))
 
 (defn update-profile
-  [db event-emitter account {:keys [email current-password password confirm] :as params} details]
+  [db event-emitter account {:keys [email current-password password confirm] :as params} details
+   keep-session-key]
   (let [email (normalize-email email)]
     (log/with-context {:tag :update-profile
                        :username account}
@@ -128,6 +130,7 @@
                                 :old-email old-email}
                                details)))
           (when password-changed?
+            (http-utils/clear-sessions-for-user! account :keep-session-key keep-session-key)
             (event/emit event-emitter :password-changed
                         (merge {:username account}
                                details)))
@@ -268,6 +271,7 @@
         (reset-password-form db reset-code (apply concat (vals errors))))
       (let [{username :user} (db/find-user-by-password-reset-code db reset-code)]
         (db/reset-user-password db username reset-code password)
+        (http-utils/clear-sessions-for-user! username)
         (log/info {:status :success
                    :username username})
         (event/emit event-emitter :password-changed

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -203,6 +203,29 @@
            "Your Clojars password was changed"}
          (into #{} (map second) @email/mock-emails))))
 
+(deftest password-change-from-profile-invalidates-other-sessions
+  (let [primary (-> (session (help/app))
+                    (register-as "fixture" "fixture@example.org" "password1234")
+                    (follow-redirect))
+        other (-> (session (help/app))
+                  (login-as "fixture" "password1234")
+                  (follow-redirect))
+        primary (-> primary
+                    (follow "profile")
+                    (fill-in "Email" "fixture@example.org")
+                    (fill-in "Current password" "password1234")
+                    (fill-in "New password" "password1234b")
+                    (fill-in "Confirm new password" "password1234b")
+                    (press "Update")
+                    (follow-redirect))]
+    (is (re-find #"Profile updated" (-> primary :response :body)))
+    (-> other
+        (visit "/profile")
+        (has (status? 302)))
+    (-> primary
+        (visit "/profile")
+        (has (status? 200)))))
+
 (deftest user-can-update-just-email
   (email/expect-mock-emails 2)
   (-> (session (help/app))

--- a/test/clojars/unit/http_utils_test.clj
+++ b/test/clojars/unit/http_utils_test.clj
@@ -1,0 +1,41 @@
+(ns clojars.unit.http-utils-test
+  (:require
+   [clojars.http-utils :as http-utils]
+   [clojure.test :refer [deftest is use-fixtures]]))
+
+(def ^:private session-store-var #'http-utils/session-store-atom)
+
+(use-fixtures :each
+              (fn [f]
+                (http-utils/clear-sessions!)
+                (f)))
+
+(deftest clear-sessions-for-user-removes-sessions-for-that-username
+  (reset! @session-store-var
+          {"k1" {:timestamp 1 :value {:cemerick.friend/identity {:username "alice"}}}
+           "k2" {:timestamp 1 :value {:cemerick.friend/identity {:username "bob"}}}
+           "k3" {:timestamp 1 :value {}}})
+  (http-utils/clear-sessions-for-user! "alice")
+  (is (= #{"k2" "k3"} (set (keys (deref @session-store-var))))))
+
+(deftest clear-sessions-for-user-keeps-session-when-asked
+  (reset! @session-store-var
+          {"keep-me" {:timestamp 1 :value {:cemerick.friend/identity {:username "alice"}}}
+           "drop-me" {:timestamp 1 :value {:cemerick.friend/identity {:username "alice"}}}})
+  (http-utils/clear-sessions-for-user! "alice" :keep-session-key "keep-me")
+  (is (= #{"keep-me"} (set (keys (deref @session-store-var))))))
+
+(deftest clear-sessions-for-user-matches-string-identity
+  (reset! @session-store-var
+          {"reg" {:timestamp 1 :value {:cemerick.friend/identity "alice"}}})
+  (http-utils/clear-sessions-for-user! "alice")
+  (is (empty? (deref @session-store-var))))
+
+(deftest clear-sessions-for-user-matches-friend-nested-identity
+  (reset! @session-store-var
+          {"sess" {:timestamp 1
+                   :value {:cemerick.friend/identity
+                           {:authentications {"bob" {:username "bob" :identity "bob"}}
+                            :current "bob"}}}})
+  (http-utils/clear-sessions-for-user! "bob")
+  (is (empty? (deref @session-store-var))))


### PR DESCRIPTION
When a user updates their password from the profile form or completes a password reset, drop all matching Ring sessions from the in-memory store except the browser that submitted the profile change (via :session/key), so other devices lose the session and cannot keep using a stolen cookie.

Resolve Friend 0.2.x session layout (:authentications / :current) when matching sessions to a username. Add unit and integration tests.

Fixes https://github.com/clojars/clojars-web/issues/930