### PR TITLE
Enable deploy notification emails for all existing users

### DIFF
--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -141,6 +141,11 @@
   (db/do-commands tx
                   ["create index jars_idx_created on jars (created)"]))
 
+(defn- enable-send-deploy-emails-for-existing-users
+  [tx]
+  (db/do-commands tx
+                  ["update users set send_deploy_emails = true where send_deploy_emails = false"]))
+
 (def migrations
   [#'initial-schema
    #'add-deploy-tokens-table
@@ -157,7 +162,8 @@
    #'add-group-settings-table
    #'rename-groups-to-permissions
    #'add-scope-to-permissions
-   #'add-created-index-to-jars-table])
+   #'add-created-index-to-jars-table
+   #'enable-send-deploy-emails-for-existing-users])
 
 (defn migrate [db]
   (db/do-commands db

--- a/src/clojars/db/migrate.clj
+++ b/src/clojars/db/migrate.clj
@@ -144,7 +144,7 @@
 (defn- enable-send-deploy-emails-for-existing-users
   [tx]
   (db/do-commands tx
-                  ["update users set send_deploy_emails = true where send_deploy_emails = false"]))
+                  ["update users set send_deploy_emails = true where send_deploy_emails = false and created < '2022-03-14'"]))
 
 (def migrations
   [#'initial-schema


### PR DESCRIPTION
## Summary
- Adds a migration that flips `send_deploy_emails` from `false` to `true` for existing users, so accounts predating this opt-in feature now receive deploy notifications. Users can still opt out via their Clojars settings.
- Fixes #928.

@tobias if we merge this then everyone will get these emails turned on, but I guess that is the point of making this change.