### PR TITLE
Delete user sessions when password changes

### DIFF
--- a/src/clojars/http_utils.clj
+++ b/src/clojars/http_utils.clj
@@ -25,6 +25,19 @@
   []
   (reset! session-store-atom {}))
 
+(defn delete-sessions-for-user!
+  "Deletes all active sessions for `username`. Used to invalidate other
+  active sessions after a password change so an attacker who got in via
+  the old password is kicked out."
+  [username]
+  (swap! session-store-atom
+         (fn [sessions]
+           (into {}
+                 (remove (fn [[_ entry]]
+                           (= username
+                              (get-in entry [:value :cemerick.friend/identity :current]))))
+                 sessions))))
+
 (defn wrap-secure-session [f]
   (let [mem-store (aging-session/aging-memory-store
                    :session-atom     session-store-atom

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -10,6 +10,7 @@
                               update-user-notifications]]
    [clojars.event :as event]
    [clojars.hcaptcha :as hcaptcha]
+   [clojars.http-utils :as http-utils]
    [clojars.log :as log]
    [clojars.notifications.common :as notif-common]
    [clojars.user-validations :as uv]
@@ -130,9 +131,14 @@
           (when password-changed?
             (event/emit event-emitter :password-changed
                         (merge {:username account}
-                               details)))
-          (assoc (redirect "/profile")
-                 :flash "Profile updated."))))))
+                               details))
+            (http-utils/delete-sessions-for-user! account))
+          (if password-changed?
+            (-> (redirect "/login")
+                (assoc :session nil
+                       :flash "Your password was updated. Please log in again."))
+            (assoc (redirect "/profile")
+                   :flash "Profile updated.")))))))
 
 (defn notifications-form
   [account user flash-msg & [errors]]
@@ -273,6 +279,7 @@
         (event/emit event-emitter :password-changed
                     (merge {:username username}
                            details))
+        (http-utils/delete-sessions-for-user! username)
         (assoc (redirect "/login")
                :flash "Your password was updated.")))))
 

--- a/test/clojars/integration/users_test.clj
+++ b/test/clojars/integration/users_test.clj
@@ -9,8 +9,7 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [kerodon.core :refer [fill-in follow follow-redirect
                          press session visit within]]
-   [kerodon.test :refer [has status? text? value?]]
-   [net.cgrand.enlive-html :as enlive]))
+   [kerodon.test :refer [has status? text? value?]]))
 
 (use-fixtures :each
   help/default-fixture
@@ -187,12 +186,9 @@
       (press "Update")
       (follow-redirect)
       (within [:div#notice]
-        (has (text? "Profile updated.")))
-      (follow "logout")
-      (follow-redirect)
-      (has (status? 200))
-      (within [:nav [:li enlive/first-child] :a]
-        (has (text? "login")))
+        (has (text? "Your password was updated. Please log in again.")))
+      (within [:div.small-section :> :h1]
+        (has (text? "Login")))
       (login-as "fixture" "password1234b")
       (follow-redirect)
       (has (status? 200))
@@ -252,12 +248,9 @@
       (press "Update")
       (follow-redirect)
       (within [:div#notice]
-        (has (text? "Profile updated.")))
-      (follow "logout")
-      (follow-redirect)
-      (has (status? 200))
-      (within [:nav [:li enlive/first-child] :a]
-        (has (text? "login")))
+        (has (text? "Your password was updated. Please log in again.")))
+      (within [:div.small-section :> :h1]
+        (has (text? "Login")))
       (login-as "fixture" "password1234b")
       (follow-redirect)
       (has (status? 200))
@@ -269,6 +262,76 @@
     (is (= "Your Clojars password was changed" title))
     (is (re-find #"has changed the password on your 'fixture'" body))
     (is (re-find #"Client IP" body))))
+
+(deftest changing-password-invalidates-other-sessions
+  (let [app (help/app)
+        ;; Session A registers and stays logged in.
+        session-a (-> (session app)
+                      (register-as "fixture" "fixture@example.org" "password1234")
+                      (follow-redirect))
+        ;; Session B logs in concurrently as the same user.
+        session-b (-> (session app)
+                      (login-as "fixture" "password1234")
+                      (follow-redirect))]
+    (-> session-b
+        (visit "/profile")
+        (has (status? 200))
+        (within [:title]
+          (has (text? "Profile (fixture) - Clojars"))))
+    ;; Change password from session A.
+    (-> session-a
+        (visit "/profile")
+        (fill-in "Current password" "password1234")
+        (fill-in "New password" "password1234b")
+        (fill-in "Confirm new password" "password1234b")
+        (press "Update")
+        (follow-redirect)
+        (within [:div.small-section :> :h1]
+          (has (text? "Login"))))
+    ;; Session B should now be logged out — visiting /profile redirects to /login.
+    (-> session-b
+        (visit "/profile")
+        (follow-redirect)
+        (within [:div.small-section :> :h1]
+          (has (text? "Login"))))))
+
+(deftest password-reset-invalidates-existing-sessions
+  (-> (session (help/app))
+      (register-as "fixture" "fixture@example.org" "password1234"))
+  (let [app (help/app)
+        ;; Existing logged-in session before the reset.
+        session-a (-> (session app)
+                      (login-as "fixture" "password1234")
+                      (follow-redirect))]
+    (-> session-a
+        (visit "/profile")
+        (has (status? 200)))
+    ;; Trigger the reset flow and submit a new password.
+    (-> (session app)
+        (visit "/")
+        (follow "login")
+        (follow "Forgot your username or password?")
+        (fill-in "Email or Username" "fixture")
+        (press "Email me a password reset link"))
+    (let [[_ _ message] (first @email/mock-emails)
+          [_ reset-password-link]
+          (re-find
+           #"To continue with the reset password process, click on the following link:\n\n([^ ]+)\n\n"
+           message)]
+      (-> (session app)
+          (visit reset-password-link)
+          (fill-in "New password" "password1234c")
+          (fill-in "Confirm new password" "password1234c")
+          (press "Update my password")
+          (follow-redirect)
+          (within [:div.small-section :> :h1]
+            (has (text? "Login")))))
+    ;; Session A is no longer authenticated.
+    (-> session-a
+        (visit "/profile")
+        (follow-redirect)
+        (within [:div.small-section :> :h1]
+          (has (text? "Login"))))))
 
 (deftest bad-update-info-should-show-error
   (-> (session (help/app))


### PR DESCRIPTION
## Summary

Closes [#930](https://github.com/clojars/clojars-web/issues/930). When a user changes their password — either via `/profile` or the forgot-password reset flow — all active in-memory sessions for that user are now wiped, so an attacker who got in via the old password is kicked out.

Profile-form changes now redirect to `/login` (with the current session cleared) when the password is updated; email-only updates still return to `/profile` as before. Implementation is a small `delete-sessions-for-user!` helper in `clojars.http-utils` that scans the aging-session store atom for entries whose Friend identity matches the username.

## Test plan

- [x] Existing `user-can-update-info` / `user-can-update-just-password` tests updated for the new redirect/flash
- [x] New `changing-password-invalidates-other-sessions` integration test (concurrent session bounced after profile-form change)
- [x] New `password-reset-invalidates-existing-sessions` integration test (logged-in session bounced after forgot-password reset)
- [ ] Reviewer: run \`docker-compose up\` + \`make test\` locally — the test postgres on port 55433 wasn't available in my workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)