### PR TITLE
Notify users when new tokens are created

### DIFF
--- a/src/clojars/notifications/token.clj
+++ b/src/clojars/notifications/token.clj
@@ -1,6 +1,32 @@
 (ns clojars.notifications.token
   (:require
-   [clojars.notifications :as notifications]))
+   [clojars.notifications :as notifications]
+   [clojars.notifications.common :as common]))
+
+(defn- scope-description [{:keys [group_name jar_name]}]
+  (cond
+    jar_name   (format "%s/%s" group_name jar_name)
+    group_name (format "%s/*" group_name)
+    :else      "*"))
+
+(defmethod notifications/notification :deploy-token-created
+  [_type mailer {:as _user username :user email :email}
+   {:as data :keys [token-name group-name jar-name single-use? expires-at]}]
+  (notifications/send
+   mailer email "A new deploy token was created on your Clojars account"
+   ["Hello,"
+    (format
+     "Someone (hopefully you) has created a new deploy token named '%s' on your '%s' Clojars account."
+     token-name
+     username)
+    (format "Scope: %s" (scope-description {:group_name group-name :jar_name jar-name}))
+    (format "Single use: %s" (if single-use? "yes" "no"))
+    (if expires-at
+      (format "Expires: %s" (str expires-at))
+      "Expires: never")
+    (common/details-table data)
+    common/did-not-take-action
+    "To review or disable deploy tokens, visit https://clojars.org/tokens"]))
 
 (defmethod notifications/notification :token-breached
   [_type mailer {:as _user :keys [email]}

--- a/src/clojars/routes/token.clj
+++ b/src/clojars/routes/token.clj
@@ -2,7 +2,9 @@
   (:require
    [clojars.auth :as auth]
    [clojars.db :as db]
+   [clojars.event :as event]
    [clojars.log :as log]
+   [clojars.routes.common :as common]
    [clojars.web.token :as view]
    [clojure.string :as str]
    [compojure.core :as compojure :refer [GET POST DELETE]]
@@ -33,12 +35,23 @@
           (+ (* (Integer/parseInt expires-in-hours) ms-per-hour))
           (Timestamp.)))))
 
-(defn- create-token [db token-name scope single-use? expires-in]
+(defn- create-token [db event-emitter request]
   (auth/with-account
     (fn [account]
-      (let [[group-name jar-name] (parse-scope scope)
-            token (db/add-deploy-token db account token-name group-name jar-name
-                                       single-use? (calculate-expires-at expires-in))]
+      (let [{:keys [name scope single_use expires_in]} (:params request)
+            single-use? (boolean single_use)
+            [group-name jar-name] (parse-scope scope)
+            expires-at (calculate-expires-at expires_in)
+            token-record (db/add-deploy-token db account name group-name jar-name
+                                                single-use? expires-at)]
+        (event/emit event-emitter :deploy-token-created
+                    (merge {:username     account
+                            :token-name   name
+                            :group-name   group-name
+                            :jar-name     jar-name
+                            :single-use?  single-use?
+                            :expires-at   expires-at}
+                           (common/request-details request)))
         (log/info {:tag :create-token
                    :username account
                    :status :success})
@@ -46,7 +59,7 @@
                           (db/find-user-tokens-by-username db account)
                           (db/jars-by-username db account)
                           (db/find-groupnames db account)
-                          {:new-token token})))))
+                          {:new-token token-record})))))
 
 (defn- find-token [db token-id]
   (when-let [id-int (try
@@ -75,11 +88,11 @@
               (assoc (redirect "/tokens")
                      :flash "Token not found."))))))))
 
-(defn routes [db]
+(defn routes [db event-emitter]
   (compojure/routes
    (GET ["/tokens"] {:keys [flash]}
         (get-tokens db flash))
-   (POST ["/tokens"] [name scope single_use expires_in]
-         (create-token db name scope single_use expires_in))
+   (POST ["/tokens"] {:as request}
+         (create-token db event-emitter request))
    (DELETE ["/tokens/:id", :id #"[0-9]+"] [id]
            (disable-token db id))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -86,7 +86,7 @@
      ;; since they both catch /:identifier
      (user/routes db event-emitter hcaptcha mailer)
      (verify/routes db event-emitter)
-     (token/routes db)
+     (token/routes db event-emitter)
      (api/routes db stats)
      (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
      (ANY "*" _

--- a/test/clojars/integration/deploy_token_creation_test.clj
+++ b/test/clojars/integration/deploy_token_creation_test.clj
@@ -1,0 +1,30 @@
+(ns clojars.integration.deploy-token-creation-test
+  (:require
+   [clojars.db :as db]
+   [clojars.email :as email]
+   ;; for defmethod side effects when handler runs
+   [clojars.notifications.token]
+   [clojars.integration.steps :refer [create-deploy-token]]
+   [clojars.test-helper :as help]
+   [clojure.test :refer [deftest is use-fixtures]]
+   [kerodon.core :refer [session]]))
+
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database
+  help/run-test-app)
+
+(deftest creating-deploy-token-sends-email-to-user
+  (db/add-user help/*db* "fixture@example.org" "fixture" "password1234")
+  (create-deploy-token (session (help/app)) "fixture" "password1234" "my-laptop")
+  (is (true? (email/wait-for-mock-emails)))
+  (let [[to subject body] (first @email/mock-emails)]
+    (is (= "fixture@example.org" to))
+    (is (= "A new deploy token was created on your Clojars account" subject))
+    (is (re-find #"Hello," body))
+    (is (re-find #"my-laptop" body))
+    (is (re-find #"Scope: \*" body))
+    (is (re-find #"Single use: no" body))
+    (is (re-find #"Expires: never" body))
+    (is (re-find #"https://clojars.org/tokens" body))
+    (is (not (re-find #"CLOJARS_" body)))))

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -1166,6 +1166,8 @@
       (fill-in [:#username] "donthemon")
       (press "Add Permission"))
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    (email/expect-mock-emails 1)
+    (is (true? (email/wait-for-mock-emails)))
     (email/expect-mock-emails 2)
     (deploy
      {:coordinates '[org.clojars.dantheman/test "0.0.1"]
@@ -1222,6 +1224,8 @@
       (fill-in [:#username] "donthemon")
       (press "Add Permission"))
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    (email/expect-mock-emails 1)
+    (is (true? (email/wait-for-mock-emails)))
     (email/expect-mock-emails 1)
     (deploy
      {:coordinates '[org.clojars.dantheman/test "0.0.1"]

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -1166,6 +1166,8 @@
       (fill-in [:#username] "donthemon")
       (press "Add Permission"))
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    ;; Creating a token sends an email. Wait for it here (not checked here;
+    ;; see deploy_token_creation_test) so the checks below are only deploy emails.
     (email/expect-mock-emails 1)
     (is (true? (email/wait-for-mock-emails)))
     (email/expect-mock-emails 2)
@@ -1224,6 +1226,8 @@
       (fill-in [:#username] "donthemon")
       (press "Add Permission"))
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    ;; Same as deploy-sends-notification-emails:
+    ;; wait for the token-creation email, then check only the deploy email.
     (email/expect-mock-emails 1)
     (is (true? (email/wait-for-mock-emails)))
     (email/expect-mock-emails 1)

--- a/test/clojars/unit/notifications/token_test.clj
+++ b/test/clojars/unit/notifications/token_test.clj
@@ -1,0 +1,70 @@
+(ns clojars.unit.notifications.token-test
+  (:require
+   [clojars.db :as db]
+   [clojars.notifications :as notifications]
+   ;; for defmethod
+   [clojars.notifications.token]
+   [clojars.test-helper :as help]
+   [clojure.test :refer [deftest is use-fixtures]])
+  (:import
+   (java.sql
+    Timestamp)
+   (java.util
+    Date)))
+
+(use-fixtures :each
+  help/default-fixture
+  help/with-clean-database)
+
+(deftest deploy-token-created-handler-sends-safe-email
+  (db/add-user help/*db* "fixture@example.org" "fixture" "password1234")
+  (let [sent (atom [])]
+    (notifications/handler
+     {:db help/*db*
+      :mailer (fn [to subj msg]
+                 (swap! sent conj [to subj msg]))}
+     :deploy-token-created
+     {:username    "fixture"
+      :token-name  "my-laptop"
+      :group-name  nil
+      :jar-name    nil
+      :single-use? false
+      :expires-at  nil
+      :remote-addr "127.0.0.1"
+      :user-agent  "TestAgent/1"
+      :timestamp   (Date.)})
+    (is (= 1 (count @sent)))
+    (let [[to subject body] (first @sent)]
+      (is (= "fixture@example.org" to))
+      (is (= "A new deploy token was created on your Clojars account" subject))
+      (is (re-find #"Hello," body))
+      (is (re-find #"my-laptop" body))
+      (is (re-find #"Scope: \*" body))
+      (is (re-find #"Single use: no" body))
+      (is (re-find #"Expires: never" body))
+      (is (re-find #"127.0.0.1" body))
+      (is (re-find #"TestAgent/1" body))
+      (is (not (re-find #"CLOJARS_" body))))))
+
+(deftest deploy-token-created-email-includes-expiry-when-set
+  (db/add-user help/*db* "fixture@example.org" "fixture" "password1234")
+  (let [t (Timestamp/valueOf "2020-06-15 12:00:00")
+        body-msg
+        (let [out (atom nil)]
+          (notifications/handler
+           {:db help/*db*
+            :mailer (fn [_to _subj msg]
+                      (reset! out msg))}
+           :deploy-token-created
+           {:username    "fixture"
+            :token-name  "t"
+            :group-name  nil
+            :jar-name    nil
+            :single-use? false
+            :expires-at  t
+            :remote-addr "127.0.0.1"
+            :user-agent  "UA"
+            :timestamp   (Date.)})
+          @out)
+        expect (format "Expires: %s" (str t))]
+    (is (re-find (re-pattern (java.util.regex.Pattern/quote expect)) body-msg))))


### PR DESCRIPTION
When someone creates a deploy token from their account, Clojars now sends a message to that user's email. The mail describes the token by name, scope, single-use flag, and expiry, plus request context (IP, user agent, time); the secret value is never included.

Fixes: https://github.com/clojars/clojars-web/issues/927