### PR TITLE
Send email notification when a deploy token is created

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,7 @@ Newest items at the top. Note that updates before 2022-August were copied from
 
 *** Unreleased
 + [[https://github.com/clojars/clojars-web/pull/934][Increase minimum password length from 8 to 12 characters]] ([[https://github.com/danielcompton][Daniel Compton]])
++ [[https://github.com/clojars/clojars-web/issues/927][Send an email when a deploy token is created]] ([[https://github.com/danielcompton][Daniel Compton]])
 
 *** [[https://github.com/clojars/clojars-web/releases/tag/2026-04-05.2249][2026-04-05.2249]]
 + [[https://github.com/clojars/clojars-web/commit/55fc4e3a741a69b84c37c4451966fe931231639c][Fix problem detail response when deploy attempted with non-token value]] ([[https://github.com/tobias][Toby Crawley]])

--- a/src/clojars/notifications/token.clj
+++ b/src/clojars/notifications/token.clj
@@ -1,6 +1,7 @@
 (ns clojars.notifications.token
   (:require
-   [clojars.notifications :as notifications]))
+   [clojars.notifications :as notifications]
+   [clojars.notifications.common :as common]))
 
 (defmethod notifications/notification :token-breached
   [_type mailer {:as _user :keys [email]}
@@ -15,4 +16,27 @@
     (if token-disabled?
       "The token was already disabled, so we took no further action."
       "This token has been disabled to prevent malicious use.")]))
+
+(defn- format-scope
+  [group-name jar-name]
+  (cond
+    (and group-name jar-name) (format "'%s/%s'" group-name jar-name)
+    group-name                (format "'%s' (any jar in group)" group-name)
+    :else                     "any group/jar"))
+
+(defmethod notifications/notification :token-created
+  [_type mailer {:as _user username :user email :email}
+   {:as data :keys [token-name group-name jar-name single-use? expires-at]}]
+  (notifications/send
+   mailer email "A deploy token was created on your Clojars account"
+   [(format
+     "Someone (hopefully you) has created a new deploy token named '%s' on your '%s' Clojars account."
+     token-name
+     username)
+    (format "Scope: %s" (format-scope group-name jar-name))
+    (format "Single use: %s" (if single-use? "yes" "no"))
+    (format "Expires: %s" (if expires-at (str expires-at) "never"))
+    (common/details-table data)
+    common/did-not-take-action
+    "To manage your deploy tokens, visit https://clojars.org/tokens"]))
 

--- a/src/clojars/routes/token.clj
+++ b/src/clojars/routes/token.clj
@@ -2,7 +2,9 @@
   (:require
    [clojars.auth :as auth]
    [clojars.db :as db]
+   [clojars.event :as event]
    [clojars.log :as log]
+   [clojars.routes.common :as common]
    [clojars.web.token :as view]
    [clojure.string :as str]
    [compojure.core :as compojure :refer [GET POST DELETE]]
@@ -33,15 +35,24 @@
           (+ (* (Integer/parseInt expires-in-hours) ms-per-hour))
           (Timestamp.)))))
 
-(defn- create-token [db token-name scope single-use? expires-in]
+(defn- create-token [db event-emitter token-name scope single-use? expires-in details]
   (auth/with-account
     (fn [account]
       (let [[group-name jar-name] (parse-scope scope)
+            expires-at (calculate-expires-at expires-in)
             token (db/add-deploy-token db account token-name group-name jar-name
-                                       single-use? (calculate-expires-at expires-in))]
+                                       single-use? expires-at)]
         (log/info {:tag :create-token
                    :username account
                    :status :success})
+        (event/emit event-emitter :token-created
+                    (merge {:username account
+                            :token-name token-name
+                            :group-name group-name
+                            :jar-name jar-name
+                            :single-use? (boolean single-use?)
+                            :expires-at expires-at}
+                           details))
         (view/show-tokens account
                           (db/find-user-tokens-by-username db account)
                           (db/jars-by-username db account)
@@ -75,11 +86,12 @@
               (assoc (redirect "/tokens")
                      :flash "Token not found."))))))))
 
-(defn routes [db]
+(defn routes [db event-emitter]
   (compojure/routes
    (GET ["/tokens"] {:keys [flash]}
         (get-tokens db flash))
-   (POST ["/tokens"] [name scope single_use expires_in]
-         (create-token db name scope single_use expires_in))
+   (POST ["/tokens"] {:as request {:keys [name scope single_use expires_in]} :params}
+         (create-token db event-emitter name scope single_use expires_in
+                       (common/request-details request)))
    (DELETE ["/tokens/:id", :id #"[0-9]+"] [id]
            (disable-token db id))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -86,7 +86,7 @@
      ;; since they both catch /:identifier
      (user/routes db event-emitter hcaptcha mailer)
      (verify/routes db event-emitter)
-     (token/routes db)
+     (token/routes db event-emitter)
      (api/routes db stats)
      (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
      (ANY "*" _


### PR DESCRIPTION
Closes #927.

Emits a `:token-created` event from the `POST /tokens` handler with the new token's name, scope, single-use flag, expiration, and request audit details (IP, user agent, timestamp). Adds a `:token-created` notification method that emails the user with those details, follows the existing `:mfa-activated` / `:password-changed` pattern (including the "if you didn't take this action" line), and links to https://clojars.org/tokens so the user can disable the token if it wasn't them.