### PR TITLE
Allow deploys that contain both gpg and ssh signatures

### DIFF
--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -152,7 +152,7 @@
    :file-missing-checksum          {:title   "File missing checksum"
                                     :details "no checksums provided for <%= filename %>"}
    :file-missing-signature         {:title   "File missing signature"
-                                    :details "file <%= filename %> has no signature"}
+                                    :details "file <%= filename %> has no <%= signature-type %> signature"}
    :maven-metadata-file-invalid    {:title   "Invalid maven-metadata.xml file"
                                     :details "failed to parse maven-metadata.xml file. Message: <%= message %>"}
    :password-not-token             {:title   "No deploy token provided"
@@ -379,16 +379,20 @@
                         :file          f
                         :filename      (.getName f)})))))
 
-(defn- assert-signatures [suffix artifacts]
+(defn- assert-signatures
+  [signature-type suffix other-signature-suffixes artifacts]
   ;; if any signatures exist, require them for every artifact
-  (let [suffix-matcher (partial match-file-name (re-pattern (format "\\%s$" suffix)))]
+  (let [suffix-matcher (partial match-file-name (re-pattern (format "\\%s$" suffix)))
+        other-suffixes-matcher (apply some-fn (mapv #(partial match-file-name (re-pattern (format "\\%s$" %))) other-signature-suffixes))]
     (when (some suffix-matcher artifacts)
       (doseq [^File f artifacts
               :when (not (suffix-matcher f))
+              :when (not (other-suffixes-matcher f))
               :when (not (.exists (io/file (str (.getAbsolutePath f) suffix))))]
         (throw-invalid :file-missing-signature
-                       {:file     f
-                        :filename (.getName f)})))))
+                       {:file           f
+                        :filename       (.getName f)
+                        :signature-type signature-type})))))
 
 (defn- validate-jar-name+version
   [name version]
@@ -416,8 +420,9 @@
 
   (let [artifacts (find-artifacts dir)]
     (validate-checksums artifacts)
-    (assert-signatures ".asc" (remove (partial match-file-name "maven-metadata.xml") artifacts))
-    (assert-signatures ".sig" (remove (partial match-file-name "maven-metadata.xml") artifacts))))
+    (let [files-sans-metadata (remove (partial match-file-name "maven-metadata.xml") artifacts)]
+      (assert-signatures "GPG" ".asc" #{".sig"} files-sans-metadata)
+      (assert-signatures "SSH" ".sig" #{".asc"} files-sans-metadata))))
 
 (defmacro profile [meta & body]
   `(let [start# (System/currentTimeMillis)]

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -855,18 +855,36 @@
   ;; This test throws on failure, so we have this assertion to satisfy kaocha
   (is true))
 
+(deftest user-can-deploy-with-gpg-and-ssh-signatures
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password1234"))
+  (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")
+        pom (io/file (io/resource "test-0.0.1/test.pom"))]
+    (deploy
+     {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+      :artifact-map {[:extension "jar"] (io/file (io/resource "test.jar"))
+                     [:extension "pom"] pom
+                     ;; any content will do since we don't validate signatures
+                     [:extension "jar.asc"] pom
+                     [:extension "pom.asc"] pom
+                     [:extension "jar.sig"] pom
+                     [:extension "pom.sig"] pom}
+      :password token}))
+  ;; This test throws on failure, so we have this assertion to satisfy kaocha
+  (is true))
+
 (deftest missing-signature-fails-the-deploy
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password1234"))
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")
         pom (io/file (io/resource "test-0.0.1/test.pom"))]
-    (doseq [suffix ["asc" "sig"]
+    (doseq [[type suffix] [["GPG" "asc"] ["SSH" "sig"]]
             :let [version (format "0.0.1-%s" suffix)
                   pom-name (format "test-%s.pom" version)]]
       (testing (format "with a suffix of .%s" suffix)
         (is (thrown-with-msg?
              DeploymentException
-             #"test-0\.0\.1-.*\.pom has no signature"
+             (re-pattern (format "test-0\\.0\\.1-.*\\.pom has no %s signature" type))
               (deploy
                {:coordinates ['org.clojars.dantheman/test version]
                 :artifact-map {[:extension "jar"] (io/file (io/resource "test.jar"))
@@ -881,7 +899,7 @@
                          :group_name "org.clojars.dantheman"
                          :jar_name "test"
                          :version version
-                         :message (format "file %s has no signature" pom-name)
+                         :message (format "file %s has no %s signature" pom-name type)
                          :tag "file-missing-signature"}))))
 
 (deftest anonymous-cannot-deploy


### PR DESCRIPTION
This was erroneously looking for signatures for the other signature files.

This also improves the error message when a signature is missing, giving
a clue as to what signature it is.
