### PR TITLE
Layout & test fixes

### DIFF
--- a/src/clojars/web/group_verification.clj
+++ b/src/clojars/web/group_verification.clj
@@ -30,20 +30,10 @@
     error   (error-flash [:h2 error]
                          (flash-details flash-data))))
 
-(def ^:private common-help
-  [[:p "See "
-    (link-to "https://github.com/clojars/clojars-web/wiki/Verified-Group-Names"
-             "the wiki")
-    " for more details on verified group names."]
-   [:p "Please "
-    (link-to "https://github.com/clojars/administration/issues/new/choose"
-             "an issue")
-    " if you run in to any problems verifying your group name."]])
-
 (defn- TXT-help
   [account]
   (let [txt-record [:code (format "\"clojars %s\"" account)]]
-    (list*
+    (list
      [:p "In order to verify a reverse-domain-based group that is based on a domain
   you control, you'll need to create a TXT DNS record on the domain of "
       txt-record
@@ -59,13 +49,12 @@
       " to the example.com domain."]
      [:p "Do a search for "
       [:code "TXT DNS <your DNS provider>"]
-      " if you are unsure how to add a TXT DNS record for your domain."]
-     common-help)))
+      " if you are unsure how to add a TXT DNS record for your domain."])))
 
 (defn- vcs-help
   [account]
   (let [repo-name (format "clojars-%s" account)]
-    (list*
+    (list
      [:p "Clojars supports groups that are based on a GitHub or Gitlab
       organization. For example, if you own "
       [:code "https://github.com/example-org/"] " or "
@@ -87,11 +76,10 @@
      [:p [:strong "Note:"]
       "You can also use this method to verify domains based on your github
       username, but you can also verify those by using the \"Login with GitHub\"
-      or \"Login with Gitlab\" feature on the Clojars login page."]
-     common-help)))
+      or \"Login with Gitlab\" feature on the Clojars login page."])))
 
 (def ^:private parent-help
-  (list*
+  (list
    [:p "A subgroup is based on a (potential) subdomain of another group. To
   verify it, the parent group has to be verified."]
    [:p "This will create the group if it doesn't already exist, and can also
@@ -103,8 +91,7 @@
     ", then you can use this verification option."]
    [:p "If you haven't verified the parent group and don't need to, you can
    verify the group using the TXT record method above, but note that the TXT
-   record will need to be on the corresponding subdomain."]
-   common-help))
+   record will need to be on the corresponding subdomain."]))
 
 (defn index
   [account flash-data]
@@ -115,41 +102,55 @@
      [:div.col-xs-6
       [:h1 heading]
       (format-flash flash-data)
+      [:div.help
+       [:p "See "
+        (link-to "https://github.com/clojars/clojars-web/wiki/Verified-Group-Names"
+                 "the wiki")
+        " for more details on verified group names. Please file "
+        (link-to "https://github.com/clojars/administration/issues/new/choose"
+                 "an issue")
+        " if you run in to any problems verifying your group name."]]
+      [:hr]
       [:div.via-txt
        [:h2 "Verification by TXT Record"]
-       [:details.help
-        [:summary "Help"]
-        (TXT-help account)]
-       (form-to [:post "/verify/group/txt"]
-                (label :group "Group name")
-                (text-field {:required    true
-                             :placeholder "com.example"}
-                            :group)
-                (label :domain "Domain with TXT record")
-                (text-field {:required    true
-                             :placeholder "example.com"}
-                            :domain)
-                (submit-button "Verify Group"))]
+       [:div.row
+        [:div.col-xs-5
+         (form-to [:post "/verify/group/txt"]
+                  (label :group "Group name")
+                  (text-field {:required    true
+                               :placeholder "com.example"}
+                              :group)
+                  (label :domain "Domain with TXT record")
+                  (text-field {:required    true
+                               :placeholder "example.com"}
+                              :domain)
+                  (submit-button "Verify Group"))]
+        [:div.col-xs-7
+         [:div.help (TXT-help account)]]]]
+      [:hr]
       [:div.via-vcs
        [:h2 "Verification of GitHub/Gitlab Repo Groups"]
-       [:details.help
-        [:summary "Help"]
-        (vcs-help account)]
-       (form-to [:post "/verify/group/vcs"]
-                (label :url "Verification Repository URL")
-                (text-field {:required    true
-                             :placeholder (format "https://github.com/example/clojars-%s"
-                                                  account)}
-                            :url)
-                (submit-button "Verify Groups"))]
+       [:div.row
+        [:div.col-xs-5
+         (form-to [:post "/verify/group/vcs"]
+                  (label :url "Verification Repository URL")
+                  (text-field {:required    true
+                               :placeholder (format "https://github.com/example/clojars-%s"
+                                                    account)}
+                              :url)
+                  (submit-button "Verify Groups"))]
+        [:div.col-xs-7
+         [:div.help (vcs-help account)]]]]
+      [:hr]
       [:div.via-parent
        [:h2 "Verification by Parent Group"]
-       [:details.help
-        [:summary "Help"]
-        parent-help]
-       (form-to [:post "/verify/group/parent"]
-                (label :group "Group name")
-                (text-field {:required    true
-                             :placeholder "com.example.ham"}
-                            :group)
-                (submit-button "Verify Group"))]])))
+       [:div.row
+        [:div.col-xs-5
+         (form-to [:post "/verify/group/parent"]
+                  (label :group "Group name")
+                  (text-field {:required    true
+                               :placeholder "com.example.ham"}
+                              :group)
+                  (submit-button "Verify Group"))]
+        [:div.col-xs-7
+         [:div.help parent-help]]]]])))

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -300,8 +300,8 @@
      heading
      {:account account}
      [:div.small-section
-      (flash flash-msg)
       [:h1 heading]
+      (flash flash-msg)
       [:div.help
        [:p
         "With two-factor authentication, you can set up a Time-based One Time Password (TOTP) device "

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -1160,16 +1160,23 @@
 (deftest deploy-sends-notification-emails
   (-> (session (help/app))
       (register-as "donthemon" "test2@example.org" "password1234"))
+
+  (email/expect-mock-emails 2)
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password1234")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "donthemon")
       (press "Add Permission"))
+  ;; Adding a user to a group sends emails to both the adder and the addee, so
+  ;; we clear away those
+  (is (true? (email/wait-for-mock-emails)))
+
   (email/expect-mock-emails 1)
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
     ;; Creating a token sends an email. Wait for it here (not checked here;
     ;; see deploy_token_creation_test) so the checks below are only deploy emails.
     (is (true? (email/wait-for-mock-emails)))
+
     (email/expect-mock-emails 2)
     (deploy
      {:coordinates '[org.clojars.dantheman/test "0.0.1"]
@@ -1220,16 +1227,23 @@
       (visit "/notification-preferences")
       (uncheck "Receive deploy notification emails?")
       (press "Update"))
+
+  (email/expect-mock-emails 2)
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password1234")
       (visit "/groups/org.clojars.dantheman")
       (fill-in [:#username] "donthemon")
       (press "Add Permission"))
+  ;; Adding a user to a group sends emails to both the adder and the addee, so
+  ;; we clear away those
+  (is (true? (email/wait-for-mock-emails)))
+
+  (email/expect-mock-emails 1)
   (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
     ;; Same as deploy-sends-notification-emails:
     ;; wait for the token-creation email, then check only the deploy email.
-    (email/expect-mock-emails 1)
     (is (true? (email/wait-for-mock-emails)))
+
     (email/expect-mock-emails 1)
     (deploy
      {:coordinates '[org.clojars.dantheman/test "0.0.1"]


### PR DESCRIPTION
### Make group verification help always visible

This moves the help to the right so it is always visible, instead of
having it hidden in a details block. Hopefully this will make users more
successful with group verification attempts.

### Properly fix flakey email tests

### Fix layout of flash on mfa page

Having it above the heading eliminated the margin between it and the header.

---

The group verification page before and after:

<img width="1361" height="1056" alt="image" src="https://github.com/user-attachments/assets/6ff4a84e-4be3-48f9-ad81-e2b65d2d5bf0" />

<img width="1361" height="1056" alt="image" src="https://github.com/user-attachments/assets/3a90d2d2-1f44-4fd2-9ccc-8a1ea0ae5ea7" />

The MFA page before and after:

<img width="729" height="573" alt="image" src="https://github.com/user-attachments/assets/4b4ddc94-a40a-40c7-ae22-e6e62201fdf8" />


<img width="729" height="501" alt="image" src="https://github.com/user-attachments/assets/bb6bb4fa-d620-4f45-8ef3-1bdde7ae3954" />
