### PR TITLE
Move MFA input to separate page on login

### DIFF
--- a/src/clojars/auth.clj
+++ b/src/clojars/auth.clj
@@ -3,7 +3,6 @@
    [buddy.core.codecs :as codecs]
    [cemerick.friend :as friend]
    [cemerick.friend.credentials :as creds]
-   [cemerick.friend.util :as friend.util]
    [cemerick.friend.workflows :as workflows]
    [clojars.db :as db]
    [clojars.event :as event]
@@ -11,7 +10,8 @@
    [clojars.util :as util]
    [clojure.string :as str]
    [one-time.core :as ot]
-   [ring.util.request :as req])
+   [ring.util.request :as req]
+   [ring.util.response :as response])
   (:import
    java.sql.Timestamp))
 
@@ -39,37 +39,98 @@
     (friend/throw-unauthorized friend/*identity*
                                {:cemerick.friend/required-roles group})))
 
+(defn- verify-password
+  [db username password]
+  (when-not (str/blank? password)
+    (let [user (db/find-user db username)]
+      (when (and (not (str/blank? (:password user)))
+                 (creds/bcrypt-verify password (:password user)))
+        user))))
+
+(defn valid-totp-token?
+  [otp {:as _user :keys [otp_secret_key]}]
+  (when-let [otp-n (-> otp
+                       (str/replace #"\s+" "")
+                       (util/parse-long))]
+    (ot/is-valid-totp-token? otp-n otp_secret_key)))
+
+(defn- validate-otp
+  [db
+   event-emitter
+   {:as user
+    recovery-code :otp_recovery_code
+    username :user}
+   otp]
+  (if (creds/bcrypt-verify otp recovery-code)
+    (do
+      (db/disable-otp! db username)
+      (event/emit event-emitter :mfa-deactivated
+                  {:username username
+                   :source :recovery-code})
+      true)
+    (valid-totp-token? otp user)))
+
 (defn- get-param
   [key form-params params]
   (or (get form-params (name key)) (get params key "")))
 
-;; copied from cemerick.friend/workflows and modified to support MFA
+(defn- make-auth
+  [username]
+  (log/info {:status :success})
+  (workflows/make-auth {:username username}
+                       {::friend/workflow          :interactive-form
+                        ::friend/redirect-on-auth? true}))
+
+(defn- verify-password-step
+  [db {:as _request :keys [form-params params session]}]
+  (let [username (get-param :username form-params params)
+        password (get-param :password form-params params)]
+    (log/with-context {:tag      :authentication
+                       :username username
+                       :type     :password}
+      (if-some [{:as _user :keys [otp_active]} (verify-password db username password)]
+        (if otp_active
+          (do
+            (log/info {:status :pending-mfa})
+            (-> (response/redirect "/login/mfa")
+                (assoc :session (assoc session ::pending-mfa-username username))))
+          (make-auth username))
+        (do
+          (log/info {:status :failed
+                     :reason :password-incorrect})
+          (response/redirect (format "/login?login_failed=Y&username=%s" username)))))))
+
+(defn- verify-mfa-step
+  [db event-emitter {:as _request :keys [form-params params session]}]
+  (if-some [username (::pending-mfa-username session)]
+    (let [otp  (get-param :otp form-params params)
+          user (db/find-user db username)]
+      (log/with-context {:tag      :authentication
+                         :username username
+                         :type     :mfa}
+        (if (validate-otp db event-emitter user otp)
+          (make-auth username)
+          (do
+            (log/info {:status :failed
+                       :reason :otp-incorrect})
+            (response/redirect "/login/mfa?otp_failed=Y")))))
+    ;; No pending username — someone hit /login/mfa directly
+    (response/redirect "/login")))
+
+(defn pending-mfa?
+  [session]
+  (some? (::pending-mfa-username session)))
+
 (defn interactive-form-with-mfa-workflow
-  [& {:keys [redirect-on-auth?] :as form-config
-      :or {redirect-on-auth? true}}]
-  (fn [{:keys [request-method params form-params] :as request}]
-    (when (and (= (friend.util/gets :login-uri
-                                    form-config
-                                    (::friend/auth-config request))
-                  (req/path-info request))
-               (= :post request-method))
-      (let [creds {:username (get-param :username form-params params)
-                   :password (get-param :password form-params params)
-                   :otp (get-param :otp form-params params)}
-            {:keys [username password]} creds]
-        (if-let [user-record (and username password
-                                  ((friend.util/gets :credential-fn
-                                                     form-config
-                                                     (::friend/auth-config request))
-                                   (with-meta creds {::friend/workflow :interactive-form})))]
-          (workflows/make-auth user-record
-                               {::friend/workflow :interactive-form
-                                ::friend/redirect-on-auth? redirect-on-auth?})
-          ((or (friend.util/gets :login-failure-handler
-                                 form-config
-                                 (::friend/auth-config request))
-               #'workflows/interactive-login-redirect)
-           (update request ::friend/auth-config merge form-config)))))))
+  [db event-emitter]
+  (fn [{:as request :keys [request-method]}]
+    (when (= :post request-method)
+      (let [path (req/path-info request)]
+        (case path
+          "/login"     (verify-password-step db request)
+          "/login/mfa" (verify-mfa-step db event-emitter request)
+          ;; else
+          nil)))))
 
 (defn parse-authorization-header
   "Parses a Basic auth header into username and password."
@@ -140,46 +201,3 @@
                            :message "The given token either doesn't exist, isn't yours, or is disabled"})
             (log/info {:status :failed
                        :reason :invalid-token})))))))
-
-(defn valid-totp-token?
-  [otp {:as _user :keys [otp_secret_key]}]
-  (when-let [otp-n (-> otp
-                       (str/replace #"\s+" "")
-                       (util/parse-long))]
-    (ot/is-valid-totp-token? otp-n otp_secret_key)))
-
-(defn- validate-otp
-  [db
-   event-emitter
-   {:as user
-    recovery-code :otp_recovery_code
-    username :user}
-   otp]
-  (if (creds/bcrypt-verify otp recovery-code)
-    (do
-      (db/disable-otp! db username)
-      (event/emit event-emitter :mfa-deactivated
-                  {:username username
-                   :source :recovery-code})
-      true)
-    (valid-totp-token? otp user)))
-
-(defn password-credential-fn [db event-emitter]
-  (fn [{:keys [username password otp]}]
-    (log/with-context {:tag :authentication
-                       :username username
-                       :type :password
-                       :otp? (boolean otp)}
-      (if (not (str/blank? password))
-        (let [{:as user :keys [otp_active]} (db/find-user db username)]
-          (if (and (not (str/blank? (:password user)))
-                   (creds/bcrypt-verify password (:password user))
-                   (or (not otp_active)
-                       (validate-otp db event-emitter user otp)))
-            (do
-              (log/info {:status :success})
-              {:username username})
-            (log/info {:status :failed
-                       :reason :password-or-otp-incorrect})))
-        (log/info {:status :failed
-                   :reason :password-blank})))))

--- a/src/clojars/routes/session.clj
+++ b/src/clojars/routes/session.clj
@@ -1,6 +1,7 @@
 (ns clojars.routes.session
   (:require
    [cemerick.friend :as friend]
+   [clojars.auth :as auth]
    [clojars.web.login :as view]
    [compojure.core :refer [GET ANY defroutes]]
    [ring.util.response :as response]))
@@ -9,5 +10,9 @@
   (GET "/login" {:keys [flash params]}
        (let [{:keys [login_failed username]} params]
          (view/login-form login_failed username flash)))
+  (GET "/login/mfa" {:keys [flash params session]}
+       (if (auth/pending-mfa? session)
+         (view/mfa-form (:otp_failed params) flash)
+         (response/redirect "/login")))
   (friend/logout
    (ANY "/logout" _ (response/redirect "/"))))

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -172,8 +172,7 @@
          (log/wrap-request-context))
      (-> (main-routes system)
          (friend/authenticate
-          {:credential-fn (auth/password-credential-fn db event-emitter)
-           :workflows [(auth/interactive-form-with-mfa-workflow)
+          {:workflows [(auth/interactive-form-with-mfa-workflow db event-emitter)
                        (registration/workflow db hcaptcha)
                        (github/workflow github http-client db)
                        (gitlab/workflow gitlab http-client db)]})

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -21,12 +21,7 @@
       [:div
        [:p.error "Incorrect username or password."]
        (when (some? (str/index-of username \@))
-         [:p.error "Make sure that you are using your username, and not your email to log in."])
-       [:p.hint "If you have not logged in since April 2012 when "
-        [:a {:href "https://groups.google.com/group/clojure/browse_thread/thread/5e0d48d2b82df39b"}
-         "the insecure password hashes were wiped"]
-        ", please use the " [:a {:href "/forgot-password"} "forgot password"]
-        " functionality to reset your password."]])
+         [:p.error "Make sure that you are using your username, and not your email to log in."])])
     (form-to [:post "/login" :class "row"]
              (label :username "Username")
              (text-field {:placeholder "bob"

--- a/src/clojars/web/login.clj
+++ b/src/clojars/web/login.clj
@@ -8,47 +8,62 @@
    [hiccup.form :refer [label text-field
                         password-field submit-button]]))
 
-(defn login-form [login_failed username message]
-  (html-doc "Login" {}
-            [:div.small-section
-             [:h1 "Login"]
-             [:p.hint "Don't have an account? "
-              (link-to "/register" "Sign up!")]
+(defn login-form
+  [login-failed username message]
+  (html-doc
+   "Login" {}
+   [:div.small-section
+    [:h1 "Login"]
+    [:p.hint "Don't have an account? "
+     (link-to "/register" "Sign up!")]
+    (flash message)
+    (when login-failed
+      [:div
+       [:p.error "Incorrect username or password."]
+       (when (some? (str/index-of username \@))
+         [:p.error "Make sure that you are using your username, and not your email to log in."])
+       [:p.hint "If you have not logged in since April 2012 when "
+        [:a {:href "https://groups.google.com/group/clojure/browse_thread/thread/5e0d48d2b82df39b"}
+         "the insecure password hashes were wiped"]
+        ", please use the " [:a {:href "/forgot-password"} "forgot password"]
+        " functionality to reset your password."]])
+    (form-to [:post "/login" :class "row"]
+             (label :username "Username")
+             (text-field {:placeholder "bob"
+                          :required true}
+                         :username)
+             (label :password "Password")
+             (password-field {:placeholder "keep it secret, keep it safe"
+                              :required true}
+                             :password)
+             (link-to {:class :hint-link} "/forgot-password" "Forgot your username or password?")
 
-             (flash message)
+             (submit-button "Login")
+             [:div#login-or "or"]
+             [:div
+              (link-to {:class "login-button github-login-button"}
+                       "/oauth/github/authorize"
+                       (helpers/retinized-image "/images/github-mark.png" "GitHub")
+                       "Login with GitHub")]
+             [:div
+              (link-to {:class :login-button} "/oauth/gitlab/authorize"
+                       (helpers/retinized-image "/images/gitlab-mark.png" "GitLab")
+                       "Login with GitLab.com")])]))
 
-             (when login_failed
-               [:div
-                [:p.error "Incorrect username, password, or two-factor code."]
-                (when (some? (str/index-of username \@))
-                  [:p.error "Make sure that you are using your username, and not your email to log in."])
-                [:p.hint "If you have not logged in since April 2012 when "
-                 [:a {:href "https://groups.google.com/group/clojure/browse_thread/thread/5e0d48d2b82df39b"}
-                  "the insecure password hashes were wiped"]
-                 ", please use the " [:a {:href "/forgot-password"} "forgot password"]
-                 " functionality to reset your password."]])
-             (form-to [:post "/login" :class "row"]
-                      (label :username "Username")
-                      (text-field {:placeholder "bob"
-                                   :required true}
-                                  :username)
-                      (label :password "Password")
-                      (password-field {:placeholder "keep it secret, keep it safe"
-                                       :required true}
-                                      :password)
-                      (label :otp "Two-Factor Code")
-                      (text-field {:placeholder "leave blank if two-factor auth not enabled"}
-                                  :otp)
-                      (link-to {:class :hint-link} "/forgot-password" "Forgot your username or password?")
-
-                      (submit-button "Login")
-                      [:div#login-or "or"]
-                      [:div
-                       (link-to {:class "login-button github-login-button"}
-                                "/oauth/github/authorize"
-                                (helpers/retinized-image "/images/github-mark.png" "GitHub")
-                                "Login with GitHub")]
-                      [:div
-                       (link-to {:class :login-button} "/oauth/gitlab/authorize"
-                                (helpers/retinized-image "/images/gitlab-mark.png" "GitLab")
-                                "Login with GitLab.com")])]))
+(defn mfa-form
+  [otp-failed message]
+  (html-doc
+   "Two-Factor Authentication" {}
+   [:div.small-section
+    [:h1 "Two-Factor Authentication"]
+    [:p.hint "Enter the 6-digit code from your authenticator app, or your recovery code."]
+    (flash message)
+    (when otp-failed
+      [:p.error "Incorrect two-factor code."])
+    (form-to [:post "/login/mfa" :class "row"]
+             (label :otp "Two-Factor Code")
+             (text-field {:placeholder "123456"
+                          :autocomplete "one-time-code"
+                          :required true}
+                         :otp)
+             (submit-button "Continue"))]))

--- a/test/clojars/integration/sessions_test.clj
+++ b/test/clojars/integration/sessions_test.clj
@@ -24,7 +24,7 @@
       (follow-redirect)
       (has (status? 200))
       (within [:div :p.error]
-        (has (text? "Incorrect username, password, or two-factor code.Make sure that you are using your username, and not your email to log in.")))))
+        (has (text? "Incorrect username or password.Make sure that you are using your username, and not your email to log in.")))))
 
 (deftest user-can-login-and-logout
   (let [app (help/app)]
@@ -53,7 +53,7 @@
         (follow-redirect)
         (has (status? 200))
         (within [:div :p.error]
-          (has (text? "Incorrect username, password, or two-factor code."))))))
+          (has (text? "Incorrect username or password."))))))
 
 (deftest user-with-password-wipe-gets-message
   (let [app (help/app)]
@@ -65,7 +65,7 @@
         (follow-redirect)
         (has (status? 200))
         (within [:div :p.error]
-          (has (text? "Incorrect username, password, or two-factor code."))))))
+          (has (text? "Incorrect username or password."))))))
 
 (deftest login-with-mfa
   (let [app (help/app)]
@@ -85,23 +85,23 @@
               (login-as "fixture" "password1234" (ot/get-totp-token otp-secret {:date the-past}))
               (follow-redirect)
               (has (status? 200))
-              (within [:div :p.error]
-                (has (text? "Incorrect username, password, or two-factor code."))))))
+              (within [:p.error]
+                (has (text? "Incorrect two-factor code."))))))
       (testing "with a token that is in the future"
         (let [the-future (Date. (+ (System/currentTimeMillis) 31000))]
           (-> (session app)
               (login-as "fixture" "password1234" (ot/get-totp-token otp-secret {:date the-future}))
               (follow-redirect)
               (has (status? 200))
-              (within [:div :p.error]
-                (has (text? "Incorrect username, password, or two-factor code."))))))
+              (within [:p.error]
+                (has (text? "Incorrect two-factor code."))))))
       (testing "with invalid token"
         (-> (session app)
             (login-as "fixture" "password1234" "1")
             (follow-redirect)
             (has (status? 200))
-            (within [:div :p.error]
-              (has (text? "Incorrect username, password, or two-factor code.")))))
+            (within [:p.error]
+              (has (text? "Incorrect two-factor code.")))))
       (testing "with recovery code"
         (-> (session app)
             (login-as "fixture" "password1234" recovery-code)

--- a/test/clojars/integration/steps.clj
+++ b/test/clojars/integration/steps.clj
@@ -14,15 +14,18 @@
 
 (defn login-as
   ([state user password]
-   (login-as state user password nil))
-  ([state user password otp]
    (-> state
        (visit "/")
        (follow "login")
        (fill-in "Username" user)
        (fill-in "Password" password)
-       (cond-> otp (fill-in "Two-Factor Code" otp))
-       (press "Login"))))
+       (press "Login")))
+  ([state user password otp]
+   (-> state
+       (login-as user password)
+       (follow-redirect)
+       (fill-in "Two-Factor Code" otp)
+       (press "Continue"))))
 
 (defn fill-in-captcha
   ([state]


### PR DESCRIPTION
This simplifies the login form by not always asking for the MFA code, and only asks for it if MFA is enabled for the user.

---

Before this change, all users saw this login page:

<img width="727" height="636" alt="image" src="https://github.com/user-attachments/assets/d904684d-c5c5-412a-8385-2a1319d082ae" />

With this change, all users see this login page: 

<img width="727" height="636" alt="image" src="https://github.com/user-attachments/assets/c988beed-3a27-4ef8-b691-42ad0108ef4b" />

And see this page after entering their username and password, but only if they have MFA enabled:

<img width="727" height="377" alt="image" src="https://github.com/user-attachments/assets/9edac112-a4f1-4b25-80cc-f3044bf2307c" />


@danielcompton would you mind taking a look? I'd like a review since it alters the login flow.