### PR TITLE
Detect compromised passwords via Have I Been Pwned

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,7 @@ Newest items at the top. Note that updates before 2022-August were copied from
 
 *** Unreleased
 + [[https://github.com/clojars/clojars-web/pull/934][Increase minimum password length from 8 to 12 characters]] ([[https://github.com/danielcompton][Daniel Compton]])
++ [[https://github.com/clojars/clojars-web/issues/725][Detect compromised passwords via Have I Been Pwned]]. Passwords are checked against the HIBP Pwned Passwords API on registration, password change, and password reset (rejecting compromised passwords up front), and on login. If a user logs in with a known-compromised password, the stored password is cleared, the user is emailed, and they must use the forgot-password flow to set a new (un-pwned) password before they can log in again. The API is queried using the k-anonymity range endpoint, so only the first 5 characters of the SHA-1 hash leave the application. ([[https://github.com/danielcompton][Daniel Compton]])
 
 *** [[https://github.com/clojars/clojars-web/releases/tag/2026-04-05.2249][2026-04-05.2249]]
 + [[https://github.com/clojars/clojars-web/commit/55fc4e3a741a69b84c37c4451966fe931231639c][Fix problem detail response when deploy attempted with non-token value]] ([[https://github.com/tobias][Toby Crawley]])

--- a/src/clojars/auth.clj
+++ b/src/clojars/auth.clj
@@ -7,6 +7,7 @@
    [cemerick.friend.workflows :as workflows]
    [clojars.db :as db]
    [clojars.event :as event]
+   [clojars.hibp :as hibp]
    [clojars.log :as log]
    [clojars.util :as util]
    [clojure.string :as str]
@@ -164,7 +165,23 @@
       true)
     (valid-totp-token? otp user)))
 
-(defn password-credential-fn [db event-emitter]
+(defn- handle-compromised-password!
+  "When a user logs in with a password that is known to HIBP, wipe the stored
+  password so the account can no longer be logged into, and emit an event so
+  the user is notified by email. They must use the forgot-password flow to
+  set a new (un-pwned) password. Returns nil so the caller treats this as a
+  failed login."
+  [db event-emitter username]
+  (db/clear-password! db username)
+  (log/audit db {:tag :password-compromised
+                 :message "Password matched a known data breach (HIBP); password cleared and reset required."})
+  (log/info {:status :failed
+             :reason :password-compromised})
+  (event/emit event-emitter :password-compromised
+              {:username username})
+  nil)
+
+(defn password-credential-fn [db event-emitter hibp]
   (fn [{:keys [username password otp]}]
     (log/with-context {:tag :authentication
                        :username username
@@ -176,9 +193,11 @@
                    (creds/bcrypt-verify password (:password user))
                    (or (not otp_active)
                        (validate-otp db event-emitter user otp)))
-            (do
-              (log/info {:status :success})
-              {:username username})
+            (if (hibp/pwned? hibp password)
+              (handle-compromised-password! db event-emitter username)
+              (do
+                (log/info {:status :success})
+                {:username username}))
             (log/info {:status :failed
                        :reason :password-or-otp-incorrect})))
         (log/info {:status :failed

--- a/src/clojars/db.clj
+++ b/src/clojars/db.clj
@@ -126,7 +126,6 @@
   [db query-data]
   (jdbc/execute! db (hsql/format query-data {:quoted true})))
 
-
 (def user-column
   "user is a reserved word, so we have to quote it."
   "\"user\"")
@@ -814,6 +813,15 @@
   [db username]
   (sql/update! db :users
                {:password_reset_code nil}
+               {user-column username}))
+
+(defn clear-password!
+  "Wipes a user's password so they can no longer log in. They must use the
+  forgot-password flow to set a new one. Used when we detect a compromised
+  password at login time."
+  [db username]
+  (sql/update! db :users
+               {:password ""}
                {user-column username}))
 
 (defn set-otp-secret-key!

--- a/src/clojars/friend/registration.clj
+++ b/src/clojars/friend/registration.clj
@@ -9,7 +9,7 @@
    [clojars.web.user :refer [register-form normalize-email]]))
 
 (defn register
-  [db hcaptcha {:keys [confirm email h-captcha-response password username]}]
+  [db hcaptcha hibp {:keys [confirm email h-captcha-response password username]}]
   (let [email (normalize-email email)]
     (log/with-context {:email email
                        :username username
@@ -18,7 +18,7 @@
                                     :email    email
                                     :password password
                                     :username username}
-                                   (uv/new-user-validations db hcaptcha confirm))]
+                                   (uv/new-user-validations db hcaptcha hibp confirm))]
         (do
           (log/info {:status :validation-failed})
           (http-utils/with-extra-csp-srcs
@@ -33,8 +33,8 @@
           (log/info {:status :success})
           (workflow/make-auth {:identity username :username username}))))))
 
-(defn workflow [db hcaptcha]
+(defn workflow [db hcaptcha hibp]
   (fn [{:keys [uri request-method params]}]
     (when (and (= "/register" uri)
                (= :post request-method))
-      (register db hcaptcha params))))
+      (register db hcaptcha hibp params))))

--- a/src/clojars/hibp.clj
+++ b/src/clojars/hibp.clj
@@ -1,0 +1,97 @@
+(ns clojars.hibp
+  "Have I Been Pwned password compromise detection.
+
+  Uses the Pwned Passwords k-anonymity range API: we hash the password with
+  SHA-1, send only the first 5 hex chars of the hash to the API, and check
+  the returned suffix list locally. The password and full hash never leave
+  the application.
+
+  See https://haveibeenpwned.com/API/v3#PwnedPasswords"
+  (:require
+   [clj-http.client :as http]
+   [clojars.log :as log]
+   [clojure.string :as str]
+   [digest])
+  (:import
+   (java.net SocketTimeoutException)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private api-url "https://api.pwnedpasswords.com/range/")
+(def ^:private user-agent "clojars-web (https://github.com/clojars/clojars-web)")
+(def ^:private request-timeout-ms 2000)
+
+(defprotocol Hibp
+  (-pwned-count
+    [self password]
+    "Returns the number of times `password` appears in the HIBP data set, or 0
+    if the password is not present. Throws on network or parse errors so the
+    caller can decide how to fail (typically: fail open)."))
+
+(defn- sha1-hex
+  ^String [^String s]
+  (str/upper-case (digest/sha-1 s)))
+
+(defn- parse-range-response
+  [^String body suffix]
+  (or (some (fn [line]
+              (let [[line-suffix line-count] (str/split line #":")]
+                (when (= line-suffix suffix)
+                  (parse-long (str/trim line-count)))))
+            (str/split-lines body))
+      0))
+
+(defrecord HttpHibp []
+  Hibp
+  (-pwned-count [_ password]
+    (let [hash (sha1-hex password)
+          prefix (subs hash 0 5)
+          suffix (subs hash 5)
+          {:keys [body status]}
+          (http/get (str api-url prefix)
+                    {:headers {"User-Agent" user-agent
+                               "Add-Padding" "true"}
+                     :socket-timeout request-timeout-ms
+                     :connection-timeout request-timeout-ms
+                     :throw-exceptions false})]
+      (if (= 200 status)
+        (parse-range-response body suffix)
+        (throw (ex-info "Unexpected HIBP response"
+                        {:status status}))))))
+
+(defrecord MockHibp [pwned-passwords]
+  Hibp
+  (-pwned-count [_ password]
+    (get @pwned-passwords password 0)))
+
+(defn pwned?
+  "Returns true if `password` is known to HIBP. Fails open: returns false if
+  HIBP is unreachable or returns an unexpected response, so users aren't locked
+  out by a third-party outage. Returns false for blank passwords."
+  [hibp password]
+  (cond
+    (nil? hibp) false
+    (str/blank? password) false
+    :else
+    (try
+      (let [n (-pwned-count hibp password)]
+        (when (pos? n)
+          (log/info {:tag :hibp-pwned :count n}))
+        (pos? n))
+      (catch SocketTimeoutException e
+        (log/warn {:tag :hibp-timeout :error (.getMessage e)})
+        false)
+      (catch Exception e
+        (log/warn {:tag :hibp-error :error (.getMessage e)})
+        false))))
+
+(defn new-hibp
+  "Production HIBP client that talks to the real HIBP API."
+  []
+  (->HttpHibp))
+
+(defn new-mock-hibp
+  "Test HIBP client. `pwned-passwords` is an atom holding a map of plaintext
+  password -> breach count."
+  [pwned-passwords]
+  (->MockHibp pwned-passwords))

--- a/src/clojars/notifications/user.clj
+++ b/src/clojars/notifications/user.clj
@@ -54,3 +54,14 @@
      username)
     (common/details-table data)
     common/did-not-take-action]))
+
+(defmethod notifications/notification :password-compromised
+  [_type mailer {:as _user username :user email :email} _data]
+  (notifications/send
+   mailer email "Your Clojars password has been reset"
+   [(format
+     "We detected that the password on your '%s' Clojars account has appeared in a known public data breach (see https://haveibeenpwned.com/Passwords)."
+     username)
+    "To protect your account, we have cleared the password. You will need to choose a new one before you can log in again."
+    "To set a new password, visit https://clojars.org/forgot-password and follow the instructions in the email we send you."
+    "We did not log you in. The login attempt that triggered this email used a known-compromised password, but we cannot tell whether it was you or someone using a leaked password. If it was you, please pick a new, unique password. If it wasn't, this email is your signal that the password should not be used anywhere."]))

--- a/src/clojars/routes/user.clj
+++ b/src/clojars/routes/user.clj
@@ -116,52 +116,52 @@
         (assoc (redirect "/mfa")
                :flash "Password incorrect.")))))
 
-(defn routes [db event-emitter hcaptcha mailer]
+(defn routes [db event-emitter hcaptcha hibp mailer]
   (compojure/routes
    (GET "/profile" {:keys [flash]}
-        (auth/with-account
-          #(view/profile-form % (db/find-user db %) flash)))
+     (auth/with-account
+       #(view/profile-form % (db/find-user db %) flash)))
    (POST "/profile" {:as request :keys [params]}
-         (auth/with-account
-           #(view/update-profile db event-emitter % params (common/request-details request))))
+     (auth/with-account
+       #(view/update-profile db event-emitter hibp % params (common/request-details request))))
 
    (GET "/mfa" {:keys [flash]}
-        (auth/with-account
-          #(view/mfa % (db/find-user db %) flash)))
+     (auth/with-account
+       #(view/mfa % (db/find-user db %) flash)))
    (POST "/mfa" {:keys [params]}
-         (auth/with-account
-           #(create-mfa db % (db/find-user db %) params)))
+     (auth/with-account
+       #(create-mfa db % (db/find-user db %) params)))
    (PUT "/mfa" {:as request :keys [params]}
-        (auth/with-account
-          #(confirm-mfa db event-emitter %
-                        (db/find-user db %) params (common/request-details request))))
+     (auth/with-account
+       #(confirm-mfa db event-emitter %
+                     (db/find-user db %) params (common/request-details request))))
    (DELETE "/mfa" {:as request :keys [params]}
-           (auth/with-account
-             #(disable-mfa db event-emitter % (db/find-user db %) params (common/request-details request))))
+     (auth/with-account
+       #(disable-mfa db event-emitter % (db/find-user db %) params (common/request-details request))))
 
    (GET "/notification-preferences" {:keys [flash]}
-        (auth/with-account
-          #(view/notifications-form % (db/find-user db %) flash)))
+     (auth/with-account
+       #(view/notifications-form % (db/find-user db %) flash)))
    (POST "/notification-preferences" {:keys [params]}
-         (auth/with-account
-           #(view/update-notifications db % params)))
+     (auth/with-account
+       #(view/update-notifications db % params)))
 
    (GET "/register" {:keys [params flash]}
-        (http-utils/with-extra-csp-srcs hcaptcha/hcaptcha-csp
-          (view/register-form hcaptcha params flash)))
+     (http-utils/with-extra-csp-srcs hcaptcha/hcaptcha-csp
+       (view/register-form hcaptcha params flash)))
 
    (GET "/forgot-password" _
-        (view/forgot-password-form))
+     (view/forgot-password-form))
    (POST "/forgot-password" {:as request :keys [params]}
-         (view/forgot-password db mailer params (common/request-details request)))
+     (view/forgot-password db mailer params (common/request-details request)))
 
    (GET "/password-resets/:reset-code" [reset-code]
-        (view/reset-password-form db reset-code))
+     (view/reset-password-form db reset-code))
 
    (POST "/password-resets/:reset-code" {:as request {:keys [reset-code password confirm]} :params}
-         (view/reset-password db event-emitter reset-code {:password password :confirm confirm} (common/request-details request)))
+     (view/reset-password db event-emitter hibp reset-code {:password password :confirm confirm} (common/request-details request)))
 
    (GET "/users/:username" [username]
-        (show db username))
+     (show db username))
    (GET "/:username" [username]
-        (show db username))))
+     (show db username))))

--- a/src/clojars/system.clj
+++ b/src/clojars/system.clj
@@ -3,6 +3,7 @@
    [clojars.email :refer [simple-mailer]]
    [clojars.event :as event]
    [clojars.hcaptcha :as hcaptcha]
+   [clojars.hibp :as hibp]
    [clojars.http-kit :as http-kit]
    [clojars.notifications :as notifications]
    ;; for defmethods
@@ -82,6 +83,7 @@
           :event-emitter  (event/new-sqs-emitter (:event-queue config))
           :event-receiver (event/new-sqs-receiver (:event-queue config))
           :hcaptcha       (hcaptcha/new-hcaptcha (:hcaptcha config))
+          :hibp           (hibp/new-hibp)
           :http           (http-kit/new-server (:http config))
           :http-client    (remote-service/new-http-remote-service)
           :mailer         (simple-mailer (:mail config))
@@ -92,7 +94,7 @@
         (component/system-using
          {:app            [:clojars-app]
           :clojars-app    [:db :github :gitlab :error-reporter :event-emitter :hcaptcha
-                           :http-client :mailer :stats :search :storage]
+                           :hibp :http-client :mailer :stats :search :storage]
           :event-emitter  [:error-reporter]
           :http           [:app]
           :notifications  [:db :mailer]

--- a/src/clojars/user_validations.clj
+++ b/src/clojars/user_validations.clj
@@ -3,16 +3,30 @@
    [cemerick.friend.credentials :as creds]
    [clojars.db :as db]
    [clojars.hcaptcha :as hcaptcha]
+   [clojars.hibp :as hibp]
    [clojars.log :as log]
    [clojure.string :as str]
    [valip.core :as valip]
    [valip.predicates :as pred]))
 
+(defn- not-pwned?
+  [hibp password]
+  ;; Skip the HIBP call if the password will be rejected by length anyway.
+  ;; valip runs every predicate even when earlier ones fail, so without this
+  ;; guard, every too-short password would still trigger an HTTP call.
+  (or (not (string? password))
+      (< (count password) 12)
+      (> (count password) 256)
+      (not (hibp/pwned? hibp password))))
+
 (defn password-validations
-  [confirm]
+  [hibp confirm]
   [[:password (pred/min-length 12) "Password must be 12 characters or longer"]
    [:password #(= % confirm) "Password and confirm password must match"]
-   [:password (pred/max-length 256) "Password must be 256 or fewer characters"]])
+   [:password (pred/max-length 256) "Password must be 256 or fewer characters"]
+   [:password (partial not-pwned? hibp)
+    (str "Password has appeared in a known data breach (see https://haveibeenpwned.com/Passwords). "
+         "Please choose a different password.")]])
 
 (defn user-validations
   ([db]
@@ -37,22 +51,22 @@
   [[:captcha (partial hcaptcha/valid-response? hcaptcha) "Captcha response is invalid."]])
 
 (defn new-user-validations
-  [db hcaptcha confirm]
+  [db hcaptcha hibp confirm]
   (concat [[:password pred/present? "Password can't be blank"]
            [:username #(not (or (db/reserved-names %)
                                 (db/find-user db %)
                                 (seq (db/group-activenames db %))))
             "Username is already taken"]]
           (user-validations db)
-          (password-validations confirm)
+          (password-validations hibp confirm)
           (captcha-validations hcaptcha)))
 
 (defn reset-password-validations
-  [db confirm]
+  [db hibp confirm]
   (concat
    [[:reset-code pred/present? "Reset code can't be blank."]
     [:reset-code #(or (str/blank? %) (db/find-user-by-password-reset-code db %)) "The reset code does not exist or it has expired."]]
-   (password-validations confirm)))
+   (password-validations hibp confirm)))
 
 (defn- correct-password?
   [db username current-password]

--- a/src/clojars/web.clj
+++ b/src/clojars/web.clj
@@ -51,51 +51,51 @@
                  :status 400}))))))
 
 (defn- main-routes
-  [{:as _system :keys [db event-emitter hcaptcha mailer search stats]}]
+  [{:as _system :keys [db event-emitter hcaptcha hibp mailer search stats]}]
   (let [db (:spec db)]
     (routes
      (GET "/" _
-          (try-account
-           #(if %
-              (dashboard db %)
-              (index-page db stats %))))
+       (try-account
+        #(if %
+           (dashboard db %)
+           (index-page db stats %))))
      (GET "/search" {:keys [params]}
-          (try-account
-           #(let [validated-params (-> params
-                                       (update :page try-parse-page))]
-              (search/search search % validated-params))))
+       (try-account
+        #(let [validated-params (-> params
+                                    (update :page try-parse-page))]
+           (search/search search % validated-params))))
      (GET "/projects" {:keys [params]}
-          (try-account
-           #(let [validated-params
-                  (-> params
-                      (update :from (partial common/check-no-null-bytes "from"))
-                      (update :page try-parse-page))]
-              (browse db % validated-params))))
+       (try-account
+        #(let [validated-params
+               (-> params
+                   (update :from (partial common/check-no-null-bytes "from"))
+                   (update :page try-parse-page))]
+           (browse db % validated-params))))
      (GET "/security" []
-          (try-account
-           #(html-doc "Security" {:account %}
-                      (raw (slurp (io/resource "security.html"))))))
+       (try-account
+        #(html-doc "Security" {:account %}
+                   (raw (slurp (io/resource "security.html"))))))
      (GET "/dmca" []
-          (try-account
-           #(html-doc "DMCA" {:account %}
-                      (raw (slurp (io/resource "dmca.html"))))))
+       (try-account
+        #(html-doc "DMCA" {:account %}
+                   (raw (slurp (io/resource "dmca.html"))))))
      session/routes
      (group/routes db event-emitter)
      (artifact/routes db stats)
      ;; user routes must go after artifact routes
      ;; since they both catch /:identifier
-     (user/routes db event-emitter hcaptcha mailer)
+     (user/routes db event-emitter hcaptcha hibp mailer)
      (verify/routes db event-emitter)
      (token/routes db)
      (api/routes db stats)
      (PUT "*" _ {:status 405 :headers {} :body "Did you mean to use /repo?"})
      (ANY "*" _
-          (try-account
-           #(not-found
-             (html-doc "Page not found" {:account %}
-                       [:div.small-section
-                        [:h1 "Page not found"]
-                        [:p "Thundering typhoons!  I think we lost it.  Sorry!"]])))))))
+       (try-account
+        #(not-found
+          (html-doc "Page not found" {:account %}
+                    [:div.small-section
+                     [:h1 "Page not found"]
+                     [:p "Thundering typhoons!  I think we lost it.  Sorry!"]])))))))
 
 (def ^:private defaults-config
   (-> ring-defaults/secure-site-defaults
@@ -141,6 +141,7 @@
            error-reporter
            event-emitter
            hcaptcha
+           hibp
            http-client
            github
            gitlab
@@ -149,28 +150,28 @@
   (let [db (:spec db)]
     (routes
      (-> (context
-          "/repo" _
-          (-> (repo/routes storage db event-emitter search)
-              (friend/authenticate
-               {:credential-fn (auth/token-credential-fn db)
-                :workflows [(workflows/http-basic :realm "clojars")]
-                :allow-anon? false
-                :unauthenticated-handler
-                (partial workflows/http-basic-deny "clojars")})
-              (repo/wrap-reject-non-token db)
-              (repo/wrap-exceptions error-reporter)
-              (repo/wrap-file (:repo (config)))
-              (log/wrap-request-context)
-              (repo/wrap-reject-double-dot)))
+           "/repo" _
+           (-> (repo/routes storage db event-emitter search)
+               (friend/authenticate
+                {:credential-fn (auth/token-credential-fn db)
+                 :workflows [(workflows/http-basic :realm "clojars")]
+                 :allow-anon? false
+                 :unauthenticated-handler
+                 (partial workflows/http-basic-deny "clojars")})
+               (repo/wrap-reject-non-token db)
+               (repo/wrap-exceptions error-reporter)
+               (repo/wrap-file (:repo (config)))
+               (log/wrap-request-context)
+               (repo/wrap-reject-double-dot)))
          (wrap-secure-session))
      (-> (token-breach/routes db event-emitter)
          (wrap-exceptions error-reporter)
          (log/wrap-request-context))
      (-> (main-routes system)
          (friend/authenticate
-          {:credential-fn (auth/password-credential-fn db event-emitter)
+          {:credential-fn (auth/password-credential-fn db event-emitter hibp)
            :workflows [(auth/interactive-form-with-mfa-workflow)
-                       (registration/workflow db hcaptcha)
+                       (registration/workflow db hcaptcha hibp)
                        (github/workflow github http-client db)
                        (gitlab/workflow gitlab http-client db)]})
          (wrap-reject-invalid-params)

--- a/src/clojars/web/user.clj
+++ b/src/clojars/web/user.clj
@@ -100,7 +100,7 @@
     (str/lower-case (str/trim email))))
 
 (defn update-profile
-  [db event-emitter account {:keys [email current-password password confirm] :as params} details]
+  [db event-emitter hibp account {:keys [email current-password password confirm] :as params} details]
   (let [email (normalize-email email)]
     (log/with-context {:tag :update-profile
                        :username account}
@@ -112,7 +112,7 @@
                                     (uv/user-validations db account)
                                     (uv/current-password-validations db account)
                                     (when-not (str/blank? password)
-                                      (uv/password-validations confirm))))]
+                                      (uv/password-validations hibp confirm))))]
         (do
           (log/info {:status :failed
                      :reason :validation-failed})
@@ -256,12 +256,12 @@
                 [:h1 "Reset your password"]
                 [:p "The reset code was not found. Please ask for a new code in the " [:a {:href "/forgot-password"} "forgot password"] " page"]))))
 
-(defn reset-password [db event-emitter reset-code {:keys [password confirm]} details]
+(defn reset-password [db event-emitter hibp reset-code {:keys [password confirm]} details]
   (log/with-context {:tag :reset-password
                      :reset-code reset-code}
     (if-let [errors (uv/validate {:password password
                                   :reset-code reset-code}
-                                 (uv/reset-password-validations db confirm))]
+                                 (uv/reset-password-validations db hibp confirm))]
       (do
         (log/info {:status :failed
                    :reason :validation-failed})

--- a/test/clojars/integration/sessions_test.clj
+++ b/test/clojars/integration/sessions_test.clj
@@ -1,9 +1,10 @@
 (ns clojars.integration.sessions-test
   (:require
    [clojars.db :as db]
+   [clojars.email :as email]
    [clojars.integration.steps :refer [create-deploy-token enable-mfa login-as register-as]]
    [clojars.test-helper :as help]
-   [clojure.test :refer [deftest testing use-fixtures]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [kerodon.core :refer [follow follow-redirect session within]]
    [kerodon.test :refer [has status? text?]]
    [net.cgrand.enlive-html :as enlive]
@@ -24,7 +25,7 @@
       (follow-redirect)
       (has (status? 200))
       (within [:div :p.error]
-        (has (text? "Incorrect username, password, or two-factor code.Make sure that you are using your username, and not your email to log in.")))))
+              (has (text? "Incorrect username, password, or two-factor code.Make sure that you are using your username, and not your email to log in.")))))
 
 (deftest user-can-login-and-logout
   (let [app (help/app)]
@@ -36,12 +37,12 @@
           (follow-redirect)
           (has (status? 200))
           (within [:.light-article :> :h1]
-            (has (text? "Dashboard (fixture)")))
+                  (has (text? "Dashboard (fixture)")))
           (follow "logout")
           (follow-redirect)
           (has (status? 200))
           (within [:nav [:li enlive/first-child] :a]
-            (has (text? "login")))))))
+                  (has (text? "login")))))))
 
 (deftest user-cant-login-with-deploy-token
   (let [app (help/app)
@@ -53,7 +54,7 @@
         (follow-redirect)
         (has (status? 200))
         (within [:div :p.error]
-          (has (text? "Incorrect username, password, or two-factor code."))))))
+                (has (text? "Incorrect username, password, or two-factor code."))))))
 
 (deftest user-with-password-wipe-gets-message
   (let [app (help/app)]
@@ -65,7 +66,7 @@
         (follow-redirect)
         (has (status? 200))
         (within [:div :p.error]
-          (has (text? "Incorrect username, password, or two-factor code."))))))
+                (has (text? "Incorrect username, password, or two-factor code."))))))
 
 (deftest login-with-mfa
   (let [app (help/app)]
@@ -78,7 +79,7 @@
             (follow-redirect)
             (has (status? 200))
             (within [:.light-article :> :h1]
-              (has (text? "Dashboard (fixture)")))))
+                    (has (text? "Dashboard (fixture)")))))
       (testing "with a token that is too old"
         (let [the-past (Date. (- (System/currentTimeMillis) 31000))]
           (-> (session app)
@@ -86,7 +87,7 @@
               (follow-redirect)
               (has (status? 200))
               (within [:div :p.error]
-                (has (text? "Incorrect username, password, or two-factor code."))))))
+                      (has (text? "Incorrect username, password, or two-factor code."))))))
       (testing "with a token that is in the future"
         (let [the-future (Date. (+ (System/currentTimeMillis) 31000))]
           (-> (session app)
@@ -94,25 +95,58 @@
               (follow-redirect)
               (has (status? 200))
               (within [:div :p.error]
-                (has (text? "Incorrect username, password, or two-factor code."))))))
+                      (has (text? "Incorrect username, password, or two-factor code."))))))
       (testing "with invalid token"
         (-> (session app)
             (login-as "fixture" "password1234" "1")
             (follow-redirect)
             (has (status? 200))
             (within [:div :p.error]
-              (has (text? "Incorrect username, password, or two-factor code.")))))
+                    (has (text? "Incorrect username, password, or two-factor code.")))))
       (testing "with recovery code"
         (-> (session app)
             (login-as "fixture" "password1234" recovery-code)
             (follow-redirect)
             (has (status? 200))
             (within [:.light-article :> :h1]
-              (has (text? "Dashboard (fixture)"))))
+                    (has (text? "Dashboard (fixture)"))))
         ;; mfa is now disabled, so login w/o an otp works
         (-> (session app)
             (login-as "fixture" "password1234")
             (follow-redirect)
             (has (status? 200))
             (within [:.light-article :> :h1]
-              (has (text? "Dashboard (fixture)"))))))))
+                    (has (text? "Dashboard (fixture)"))))))))
+
+(deftest login-with-pwned-password-clears-password-and-emails-user
+  (let [app (help/app)
+        password "password1234"]
+    (-> (session app)
+        (register-as "fixture" "fixture@example.org" password))
+    ;; Mark the password as compromised in the mock HIBP client.
+    (help/mark-pwned! password)
+    (email/expect-mock-emails 1)
+    (-> (session app)
+        (login-as "fixture" password)
+        (follow-redirect)
+        (has (status? 200))
+        (within [:div :p.error]
+                (has (text? "Incorrect username, password, or two-factor code."))))
+    (testing "the stored password is cleared so the account is locked"
+      (let [user (db/find-user help/*db* "fixture")]
+        (is (or (nil? (:password user))
+                (= "" (:password user))))))
+    (testing "the user receives a notification email"
+      (is (email/wait-for-mock-emails))
+      (let [[to subject body] (first @email/mock-emails)]
+        (is (= "fixture@example.org" to))
+        (is (= "Your Clojars password has been reset" subject))
+        (is (re-find #"known public data breach" body))
+        (is (re-find #"forgot-password" body))))
+    (testing "subsequent login with the same password still fails"
+      (-> (session app)
+          (login-as "fixture" password)
+          (follow-redirect)
+          (has (status? 200))
+          (within [:div :p.error]
+                  (has (text? "Incorrect username, password, or two-factor code.")))))))

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -7,6 +7,7 @@
    [clojars.dev.setup :as setup]
    [clojars.email :as email]
    [clojars.errors :as errors]
+   [clojars.hibp :as hibp]
    [clojars.http-kit :as http-kit]
    [clojars.oauth.service :as oauth-service]
    [clojars.s3 :as s3]
@@ -122,6 +123,12 @@
 (defn app []
   (web/clojars-app system))
 
+(defn mark-pwned!
+  "Marks `password` (and optionally more) as compromised in the mock HIBP
+  client for the duration of the current test."
+  [& passwords]
+  (swap! (:pwned-passwords (:hibp system)) into (zipmap passwords (repeat 1))))
+
 (defn- with-test-system*
   [f]
   (binding [config/*profile* "test"]
@@ -131,6 +138,7 @@
                       (assoc (system/new-system (config/config))
                              :repo-bucket (s3/mock-s3-client)
                              :error-reporter (quiet-reporter)
+                             :hibp (hibp/new-mock-hibp (atom {}))
                              :index-factory memory-index
                              :mailer (email/mock-mailer)
                              :stats (no-stats)

--- a/test/clojars/unit/hibp_test.clj
+++ b/test/clojars/unit/hibp_test.clj
@@ -1,0 +1,55 @@
+(ns clojars.unit.hibp-test
+  (:require
+   [clj-http.client]
+   [clojars.hibp :as hibp]
+   [clojure.test :refer [deftest is testing]]
+   [matcher-combinators.test])
+  (:import
+   (java.net SocketTimeoutException)))
+
+(deftest mock-hibp-detects-pwned-passwords
+  (let [client (hibp/new-mock-hibp (atom {"hunter2" 12345}))]
+    (is (true? (hibp/pwned? client "hunter2")))
+    (is (false? (hibp/pwned? client "something-else")))))
+
+(deftest pwned?-handles-blank-passwords
+  (let [client (hibp/new-mock-hibp (atom {"" 1}))]
+    (is (false? (hibp/pwned? client "")))
+    (is (false? (hibp/pwned? client nil)))))
+
+(deftest pwned?-fails-open-on-network-error
+  (let [client (reify hibp/Hibp
+                 (-pwned-count [_ _]
+                   (throw (SocketTimeoutException. "boom"))))]
+    (is (false? (hibp/pwned? client "any-password")))))
+
+(deftest pwned?-fails-open-on-other-errors
+  (let [client (reify hibp/Hibp
+                 (-pwned-count [_ _]
+                   (throw (ex-info "unexpected" {}))))]
+    (is (false? (hibp/pwned? client "any-password")))))
+
+(deftest http-hibp-parses-range-response
+  ;; "password" SHA-1 = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+  ;; Prefix: 5BAA6, Suffix: 1E4C9B93F3F0682250B6CF8331B7EE68FD8
+  (let [http-hibp (hibp/->HttpHibp)]
+    (testing "parse-range-response is package-private; assert via public protocol behaviour by stubbing http"
+      (with-redefs [clj-http.client/get
+                    (fn [_url _opts]
+                      {:status 200
+                       :body (str "0018A45C4D1DEF81644B54AB7F969B88D65:1\r\n"
+                                  "1E4C9B93F3F0682250B6CF8331B7EE68FD8:1234\r\n"
+                                  "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:7\r\n")})]
+        (is (= 1234 (hibp/-pwned-count http-hibp "password")))))
+    (testing "returns 0 when suffix not present"
+      (with-redefs [clj-http.client/get
+                    (fn [_url _opts]
+                      {:status 200
+                       :body "0018A45C4D1DEF81644B54AB7F969B88D65:1\r\n"})]
+        (is (= 0 (hibp/-pwned-count http-hibp "password")))))
+    (testing "throws on non-200 so caller can fail open"
+      (with-redefs [clj-http.client/get
+                    (fn [_url _opts]
+                      {:status 503 :body ""})]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (hibp/-pwned-count http-hibp "password")))))))

--- a/test/clojars/unit/user_validations_test.clj
+++ b/test/clojars/unit/user_validations_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojars.db :as db]
    [clojars.hcaptcha :as hcaptcha]
+   [clojars.hibp :as hibp]
    [clojars.remote-service :as remote-service]
    [clojars.test-helper :as help]
    [clojars.user-validations :as uv]
@@ -11,19 +12,30 @@
 (use-fixtures :each
   help/with-clean-database)
 
+(defn- mock-hibp [& pwned]
+  (hibp/new-mock-hibp (atom (zipmap pwned (repeat 1)))))
+
 (deftest test-password-validations
-  (is (nil? (uv/validate {:password "abcdefghijkl"} (uv/password-validations "abcdefghijkl"))))
-  (is (match?
-       {:password ["Password must be 12 characters or longer"]}
-       (uv/validate {:password "a"} (uv/password-validations "a"))))
-  (is (match?
-       {:password ["Password must be 12 characters or longer"
-                   "Password and confirm password must match"]}
-       (uv/validate {:password "a"} (uv/password-validations "b"))))
-  (let [long-password (apply str (repeat 257 "a"))]
+  (let [hibp (mock-hibp)]
+    (is (nil? (uv/validate {:password "abcdefghijkl"} (uv/password-validations hibp "abcdefghijkl"))))
     (is (match?
-         {:password ["Password must be 256 or fewer characters"]}
-         (uv/validate {:password long-password} (uv/password-validations long-password))))))
+         {:password ["Password must be 12 characters or longer"]}
+         (uv/validate {:password "a"} (uv/password-validations hibp "a"))))
+    (is (match?
+         {:password ["Password must be 12 characters or longer"
+                     "Password and confirm password must match"]}
+         (uv/validate {:password "a"} (uv/password-validations hibp "b"))))
+    (let [long-password (apply str (repeat 257 "a"))]
+      (is (match?
+           {:password ["Password must be 256 or fewer characters"]}
+           (uv/validate {:password long-password} (uv/password-validations hibp long-password)))))))
+
+(deftest test-pwned-password-rejected
+  (let [hibp (mock-hibp "leaked-password-123")]
+    (is (match?
+         {:password [#"known data breach"]}
+         (uv/validate {:password "leaked-password-123"}
+                      (uv/password-validations hibp "leaked-password-123"))))))
 
 (deftest test-user-validations
   (is (nil? (uv/validate {:email "foo@example.com"
@@ -69,7 +81,8 @@
 
 (deftest test-new-user-validations
   (remote-service/with-mocking
-    (let [hcaptcha-service (hcaptcha/new-mock-hcaptcha)]
+    (let [hcaptcha-service (hcaptcha/new-mock-hcaptcha)
+          hibp (mock-hibp)]
       (remote-service/set-responder '-validate-hcaptcha-response
                                     (fn [request-info]
                                       {:success (= "valid" (get-in request-info [:form-params :response]))}))
@@ -78,14 +91,14 @@
                          :password "password1234a"
                          :username "auser"
                          :captcha "valid"}
-                        (uv/new-user-validations help/*db*  hcaptcha-service "password1234a"))))
+                        (uv/new-user-validations help/*db* hcaptcha-service hibp "password1234a"))))
       (is (match?
            {:captcha ["Captcha response is invalid."]}
            (uv/validate {:email "foo@example.com"
                          :password "password1234a"
                          :username "auser"
                          :captcha "invalid"}
-                        (uv/new-user-validations help/*db*  hcaptcha-service "password1234a"))))
+                        (uv/new-user-validations help/*db* hcaptcha-service hibp "password1234a"))))
       (is (match?
            {:password ["Password can't be blank"
                        "Password must be 12 characters or longer"
@@ -94,7 +107,7 @@
                          :password ""
                          :username "auser"
                          :captcha "valid"}
-                        (uv/new-user-validations help/*db*  hcaptcha-service "password1234a"))))
+                        (uv/new-user-validations help/*db* hcaptcha-service hibp "password1234a"))))
       (db/add-user help/*db* "foo@example.com" "auser" "password1234a")
       (is (match?
            {:username ["Username is already taken"]
@@ -103,14 +116,14 @@
                          :password "password1234a"
                          :username "auser"
                          :captcha "valid"}
-                        (uv/new-user-validations help/*db*  hcaptcha-service "password1234a"))))
+                        (uv/new-user-validations help/*db* hcaptcha-service hibp "password1234a"))))
       (is (match?
            {:username ["Username is already taken"]}
            (uv/validate {:email "foo2@example.com"
                          :password "password1234a"
                          :username "admin"
                          :captcha "valid"}
-                        (uv/new-user-validations help/*db*  hcaptcha-service "password1234a"))))
+                        (uv/new-user-validations help/*db* hcaptcha-service hibp "password1234a"))))
       (db/add-group help/*db* "auser" "agroup")
       (is (match?
            {:username ["Username is already taken"]}
@@ -118,25 +131,26 @@
                          :password "password1234a"
                          :username "agroup"
                          :captcha "valid"}
-                        (uv/new-user-validations help/*db*  hcaptcha-service "password1234a")))))))
+                        (uv/new-user-validations help/*db* hcaptcha-service hibp "password1234a")))))))
 
 (deftest test-reset-password-validations
   (db/add-user help/*db* "foo@example.com" "auser" "password1234a")
-  (let [reset-code (db/set-password-reset-code! help/*db* "auser")]
+  (let [reset-code (db/set-password-reset-code! help/*db* "auser")
+        hibp (mock-hibp)]
     (is (nil?
          (uv/validate {:reset-code reset-code
                        :password "password1234a"}
-                      (uv/reset-password-validations help/*db* "password1234a"))))
+                      (uv/reset-password-validations help/*db* hibp "password1234a"))))
     (is (match?
          {:reset-code ["Reset code can't be blank."]}
          (uv/validate {:reset-code ""
                        :password "password1234a"}
-                      (uv/reset-password-validations help/*db* "password1234a"))))
+                      (uv/reset-password-validations help/*db* hibp "password1234a"))))
     (is (match?
          {:reset-code ["The reset code does not exist or it has expired."]}
          (uv/validate {:reset-code "foo"
                        :password "password1234a"}
-                      (uv/reset-password-validations help/*db* "password1234a"))))))
+                      (uv/reset-password-validations help/*db* hibp "password1234a"))))))
 
 (deftest current-password-validations
   (db/add-user help/*db* "foo@example.com" "auser" "password1234a")


### PR DESCRIPTION
Closes #725. Passwords are checked against the HIBP Pwned Passwords range API (k-anonymity — only the first 5 chars of the SHA-1 hash leave the app) on registration, password change, and reset (rejecting compromised passwords up front), and on login. A login with a known-compromised password clears the stored password, emails the user, and forces them through the forgot-password flow before they can log in again. The new `clojars.hibp` client fails open on errors and short-timeouts so a third-party outage can't lock users out, and the length-bounded validation guard avoids an HTTP call for passwords that fail length checks anyway. Wired in via a new `:hibp` system component (real + mock) with unit and integration test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)