### PR TITLE
Add cljfmt formatting config and lint/tidy scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
           background: true
       - run: make migrate-db
       - run: make check-dependabot
+      - run:
+          name: Check formatting
+          command: ./scripts/lint
       - run: make lint
       - run: make test
       - store_test_results:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ check:
 lint:
 	./bin/lint
 
+.PHONY: tidy
+tidy:
+	./scripts/tidy
+
 .PHONY: migrate-db
 migrate-db:
 	clojure -M:migrate-db

--- a/cljfmt.edn
+++ b/cljfmt.edn
@@ -1,0 +1,25 @@
+{;; Codebase keeps occasional double blank lines between top-level forms.
+ :remove-consecutive-blank-lines? false
+
+ :extra-indents
+ {;; Compojure route macros: existing style aligns the body under the
+  ;; route path argument (default arg-alignment) rather than cljfmt's
+  ;; built-in [:inner 0] (2-space body indent). Disable the built-in
+  ;; rule by setting an inner depth that never matches.
+  ANY     ^:replace [[:inner 99]]
+  DELETE  ^:replace [[:inner 99]]
+  GET     ^:replace [[:inner 99]]
+  HEAD    ^:replace [[:inner 99]]
+  OPTIONS ^:replace [[:inner 99]]
+  PATCH   ^:replace [[:inner 99]]
+  POST    ^:replace [[:inner 99]]
+  PUT     ^:replace [[:inner 99]]
+  context ^:replace [[:inner 99]]
+
+  ;; clojure.test assertion forms: existing tests align the body
+  ;; under the predicate's first arg.
+  thrown?          [[:block 1]]
+  thrown-with-msg? [[:block 2]]
+
+  ;; kerodon helper: body aligns under the selector vector.
+  within           [[:block 1]]}}

--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,7 @@
   ;; & CVE-2024-36124
   com.taoensso/nippy {:mvn/version "3.6.0"}
   comb/comb {:mvn/version "1.0.0"}
-  
+
   digest/digest {:mvn/version "1.4.10"}
   duct/duct {:mvn/version "0.8.2"}
   duct/hikaricp-component {:mvn/version "0.1.2"
@@ -49,7 +49,7 @@
   metosin/malli {:mvn/version "0.20.0"}
   metosin/muuntaja {:mvn/version "0.6.11"}
   metosin/muuntaja-yaml {:mvn/version "0.6.11"}
-  
+
   net.cgrand/regex {:mvn/version "1.1.0"}
 
   ;; This fork of http-kit supports :status-message to allow us to
@@ -104,6 +104,9 @@
            :check {:extra-deps {athos/clj-check {:git/url "https://github.com/athos/clj-check.git"
                                                  :sha "d997df866b2a04b7ce7b17533093ee0a2e2cb729"}}
                    :main-opts ["-m" "clj-check.check"]}
+
+           :cljfmt {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.16.4"}}
+                    :main-opts ["-m" "cljfmt.main"]}
 
            :dev {:extra-deps
                  {clj-commons/pomegranate {:mvn/version "1.3.26"}

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Check Clojure formatting with cljfmt. See cljfmt.edn for the rule set.
+# Run scripts/tidy to fix any reported issues.
+
+set -euo pipefail
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$dir/.."
+
+exec clojure -M:cljfmt check src test dev build.clj

--- a/scripts/tidy
+++ b/scripts/tidy
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Fix Clojure formatting with cljfmt. See cljfmt.edn for the rule set.
+
+set -euo pipefail
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$dir/.."
+
+exec clojure -M:cljfmt fix src test dev build.clj

--- a/src/clojars/admin.clj
+++ b/src/clojars/admin.clj
@@ -207,13 +207,13 @@
 
 (defn handler [mapping]
   (nrepl/default-handler
-    (with-meta
-      (fn [h]
-        (fn [{:keys [session] :as msg}]
-          (swap! session merge mapping)
-          (h msg)))
-      {:clojure.tools.nrepl.middleware/descriptor {:requires #{"clone"}
-                                                   :expects #{"eval"}}})))
+   (with-meta
+     (fn [h]
+       (fn [{:keys [session] :as msg}]
+         (swap! session merge mapping)
+         (h msg)))
+     {:clojure.tools.nrepl.middleware/descriptor {:requires #{"clone"}
+                                                  :expects #{"eval"}}})))
 
 (defn init [db search storage]
   (when-let [port (:nrepl-port (config))]


### PR DESCRIPTION
Sets up a `cljfmt.edn` tuned to the repo's existing code style — it preserves the occasional double blank lines, keeps the compojure route indentation (`GET`/`POST`/etc.), and matches the `clojure.test` and kerodon assertion alignment, so running cljfmt doesn't churn unrelated code. Adds a `:cljfmt` deps alias along with `scripts/lint` (check) and `scripts/tidy` (fix) wrappers, a `make tidy` target, and a CircleCI "Check formatting" step. Reformats the single outlier block in `admin.clj` so the codebase passes the check cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)