### PR TITLE
Update circleci config to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 jobs:
   build:
     docker:


### PR DESCRIPTION
2.0 will no longer work after 2026-08-17. The config itself is valid for 2.1.

See https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-august-17-2026/54719