### PR TITLE
Don't allow dynamic versions in pom or module deps

### DIFF
--- a/src/clojars/gradle.clj
+++ b/src/clojars/gradle.clj
@@ -1,7 +1,38 @@
 (ns clojars.gradle
   (:require
    [cheshire.core :as json]
-   [clojure.java.io :as io]))
+   [clojars.maven :as maven]
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+(defn range-version?
+  [v]
+  ;; See https://docs.gradle.org/current/userguide/dependency_versions.html
+  (or (maven/range-version? v)
+      (= "+" v)
+      (str/ends-with? v ".+")))
+
+;; See https://docs.gradle.org/current/userguide/dependency_versions.html
+(let [dynamic-latest-versions #{"latest.integration" "latest.release"}]
+  (defn latest-metaversion-version?
+    [v]
+    (contains? dynamic-latest-versions v)))
+
+;; See https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md#version-value 
+(defn dependency-versions
+  [module]
+  (reduce
+   (fn [acc variant]
+     (into acc (comp
+                (map
+                 (fn [{:keys [version]}]
+                   (or (:strictly version)
+                       (:requires version)
+                       (:prefers version))))
+                (remove nil?))
+           (:dependencies variant)))
+   []
+   (:variants module)))
 
 (defn module-to-map
   "Reads a Gradle module file returning a map"

--- a/src/clojars/maven.clj
+++ b/src/clojars/maven.clj
@@ -19,7 +19,9 @@
     License
     Model
     Scm)
-   org.apache.maven.model.io.xpp3.MavenXpp3Reader))
+   (org.apache.maven.model.io.xpp3
+    MavenXpp3Reader
+    MavenXpp3Writer)))
 
 (set! *warn-on-reflection* true)
 
@@ -75,9 +77,15 @@
 
 (defn read-pom
   "Reads a pom file returning a maven Model object."
-  [file]
+  ^Model [file]
   (with-open [reader (io/reader file)]
     (.read (MavenXpp3Reader.) reader)))
+
+(defn write-pom
+  "Writes the pom file from the given model"
+  [^Model model file]
+  (with-open [writer (io/writer file)]
+    (.write (MavenXpp3Writer.) writer model)))
 
 (def pom-to-map (comp model-to-map read-pom))
 
@@ -203,6 +211,15 @@
 
 (defn snapshot-version? [^String version]
   (.endsWith version "-SNAPSHOT"))
+
+(defn range-version?
+  [v]
+  (some? (str/index-of v \,)))
+
+(let [dynamic-latest-versions #{"LATEST" "RELEASE"}]
+  (defn latest-metaversion-version?
+    [v]
+    (contains? dynamic-latest-versions v)))
 
 (defn central-metadata
   "Read the metadata from maven central for the given artifact."

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -127,66 +127,72 @@
 
 (def ^:private failure-details
   ;; These use comb for templating, and can access any key in the metadata passed to throw-invalid
-  {:central-shadow                         {:title   "Cannot shadow Maven Central"
-                                            :details "shadowing Maven Central artifacts is not allowed. See https://bit.ly/3rTLqxZ"}
-   :central-shadow-check-failure           {:title   "Maven Central shadow check failed"
-                                            :details "failed to contact Maven Central to verify project name. See https://bit.ly/3rTLqxZ"}
-   :gradle-module-invalid                  {:title   "Invalid Gradle module"
-                                            :details "failed to parse Gradle module. Message: <%= message %>"}
-   :gradle-module-mismatch-group           {:title   "Invalid Gradle module"
-                                            :details "the component group in the gradle module (<%= module-value %>) does not match the group you are deploying to (<%= value %>)"}
-   :gradle-module-mismatch-module          {:title   "Invalid Gradle module"
-                                            :details "the component module in the gradle module (<%= module-value %>) does not match the module you are deploying to (<%= value %>)"}
-   :gradle-module-mismatch-version         {:title   "Invalid Gradle module"
-                                            :details "the component version in the gradle module (<%= module-value %>) does not match the version you are deploying to (<%= value %>)"}
-   :group-no-access                        {:title   "Deploy group not accessible"
-                                            :details "You don't have access to the '<%= group %>/<%= project %>' project"}
-   :group-non-existent                     {:title   "Deploy group does not exist"
-                                            :details "Group '<%= group %>' doesn't exist. See https://bit.ly/3MuKGXO"}
-   :group-non-verified                     {:title   "Deploy group isn't verified"
-                                            :details "Group '<%= group %>' isn't verified, so can't contain new projects. See https://bit.ly/3MuKGXO"}
-   :group-requires-mfa                     {:title   "Deploy group requires MFA"
-                                            :details "The group '<%= group %>' requires you to have two-factor auth enabled to deploy. See https://bit.ly/45qrtA8"}
-   :file-invalid-checksum                  {:title   "Invalid checksum"
-                                            :details "invalid <%= checksum-type %> checksum for <%= filename %>"}
-   :file-missing-checksum                  {:title   "File missing checksum"
-                                            :details "no checksums provided for <%= filename %>"}
-   :file-missing-signature                 {:title   "File missing signature"
-                                            :details "file <%= filename %> has no <%= signature-type %> signature"}
-   :maven-metadata-file-invalid            {:title   "Invalid maven-metadata.xml file"
-                                            :details "failed to parse maven-metadata.xml file. Message: <%= message %>"}
-   :password-not-token                     {:title   "No deploy token provided"
-                                            :details "a deploy token is required to deploy. See https://bit.ly/3LmCclv"}
-   :pom-file-latest-metaversion-dependency {:title   "Invalid POM file"
-                                            :details "the POM file includes a dependency with a version of 'LATEST' or 'RELEASE'. See https://bit.ly/44Z4Ggp"}
-   :pom-file-invalid                       {:title   "Invalid POM file"
-                                            :details "failed to parse POM file. Message: <%= message %>"}
-   :pom-file-mismatch-group                {:title   "Invalid POM file"
-                                            :details "the group in the pom (<%= pom-value %>) does not match the group you are deploying to (<%= value %>)"}
-   :pom-file-mismatch-name                 {:title   "Invalid POM file"
-                                            :details "the name in the pom (<%= pom-value %>) does not match the name you are deploying to (<%= value %>)"}
-   :pom-file-mismatch-version              {:title   "Invalid POM file"
-                                            :details "the version in the pom (<%= pom-value %>) does not match the version you are deploying to (<%= value %>)"}
-   :pom-file-missing                       {:title   "Missing POM file"
-                                            :details "No POM file was uploaded"}
-   :pom-file-missing-license               {:title   "Invalid POM file"
-                                            :details "the POM file does not include a license. See https://bit.ly/3PQunZU"}
-   :pom-file-range-dependency              {:title   "Invalid POM file"
-                                            :details "the POM file includes a dependency with a version range. See https://bit.ly/44Z4Ggp"}
-   :pom-file-snapshot-dependency           {:title   "Invalid POM file"
-                                            :details "the POM file includes a dependency with a SNAPSHOT version. See https://bit.ly/44Z4Ggp"}
-   :project-name-invalid                   {:title   "Invalid project name"
-                                            :details "project names must consist solely of lowercase letters, numbers, hyphens and underscores. See https://bit.ly/3MuL20A"}
-   :redeploy-non-snapshot                  {:title   "Non-SNAPSHOT redeploy"
-                                            :details "redeploying non-snapshots is not allowed. See https://bit.ly/3EYzhwT"}
-   :token-single-use-used                  {:title   "Deploy token used"
-                                            :details "The provided single-use token has already been used"}
-   :token-scope-mismatch                   {:title   "Deploy token scope mismatch"
-                                            :details "The provided token's scope doesn't allow deploying this artifact. See https://bit.ly/3LmCclv"}
-   :unknown-upload-error                   {:title   "Unknown error"
-                                            :details "Unknown error. Message: <%= message %>"}
-   :version-invalid                        {:title   "Invalid version"
-                                            :details "version strings must consist solely of letters, numbers, dots, pluses, hyphens and underscores. See https://bit.ly/3Kf5KzX"}})
+  {:central-shadow                              {:title   "Cannot shadow Maven Central"
+                                                 :details "shadowing Maven Central artifacts is not allowed. See https://bit.ly/3rTLqxZ"}
+   :central-shadow-check-failure                {:title   "Maven Central shadow check failed"
+                                                 :details "failed to contact Maven Central to verify project name. See https://bit.ly/3rTLqxZ"}
+   :gradle-module-invalid                       {:title   "Invalid Gradle module"
+                                                 :details "failed to parse Gradle module. Message: <%= message %>"}
+   :gradle-module-latest-metaversion-dependency {:title   "Invalid Gradle module"
+                                                 :details "the Gradle module includes a dependency with a version of 'latest.integration' or 'latest.release'. See https://bit.ly/44Z4Ggp"}
+   :gradle-module-mismatch-group                {:title   "Invalid Gradle module"
+                                                 :details "the component group in the gradle module (<%= module-value %>) does not match the group you are deploying to (<%= value %>)"}
+   :gradle-module-mismatch-module               {:title   "Invalid Gradle module"
+                                                 :details "the component module in the gradle module (<%= module-value %>) does not match the module you are deploying to (<%= value %>)"}
+   :gradle-module-mismatch-version              {:title   "Invalid Gradle module"
+                                                 :details "the component version in the gradle module (<%= module-value %>) does not match the version you are deploying to (<%= value %>)"}
+   :gradle-module-range-dependency              {:title   "Invalid Gradle module"
+                                                 :details "the Gradle module includes a dependency with a version range. See https://bit.ly/44Z4Ggp"}
+   :gradle-module-snapshot-dependency           {:title   "Invalid Gradle module"
+                                                 :details "the Gradle module includes a dependency with a SNAPSHOT version. See https://bit.ly/44Z4Ggp"}
+   :group-no-access                             {:title   "Deploy group not accessible"
+                                                 :details "You don't have access to the '<%= group %>/<%= project %>' project"}
+   :group-non-existent                          {:title   "Deploy group does not exist"
+                                                 :details "Group '<%= group %>' doesn't exist. See https://bit.ly/3MuKGXO"}
+   :group-non-verified                          {:title   "Deploy group isn't verified"
+                                                 :details "Group '<%= group %>' isn't verified, so can't contain new projects. See https://bit.ly/3MuKGXO"}
+   :group-requires-mfa                          {:title   "Deploy group requires MFA"
+                                                 :details "The group '<%= group %>' requires you to have two-factor auth enabled to deploy. See https://bit.ly/45qrtA8"}
+   :file-invalid-checksum                       {:title   "Invalid checksum"
+                                                 :details "invalid <%= checksum-type %> checksum for <%= filename %>"}
+   :file-missing-checksum                       {:title   "File missing checksum"
+                                                 :details "no checksums provided for <%= filename %>"}
+   :file-missing-signature                      {:title   "File missing signature"
+                                                 :details "file <%= filename %> has no <%= signature-type %> signature"}
+   :maven-metadata-file-invalid                 {:title   "Invalid maven-metadata.xml file"
+                                                 :details "failed to parse maven-metadata.xml file. Message: <%= message %>"}
+   :password-not-token                          {:title   "No deploy token provided"
+                                                 :details "a deploy token is required to deploy. See https://bit.ly/3LmCclv"}
+   :pom-file-latest-metaversion-dependency      {:title   "Invalid POM file"
+                                                 :details "the POM file includes a dependency with a version of 'LATEST' or 'RELEASE'. See https://bit.ly/44Z4Ggp"}
+   :pom-file-invalid                            {:title   "Invalid POM file"
+                                                 :details "failed to parse POM file. Message: <%= message %>"}
+   :pom-file-mismatch-group                     {:title   "Invalid POM file"
+                                                 :details "the group in the pom (<%= pom-value %>) does not match the group you are deploying to (<%= value %>)"}
+   :pom-file-mismatch-name                      {:title   "Invalid POM file"
+                                                 :details "the name in the pom (<%= pom-value %>) does not match the name you are deploying to (<%= value %>)"}
+   :pom-file-mismatch-version                   {:title   "Invalid POM file"
+                                                 :details "the version in the pom (<%= pom-value %>) does not match the version you are deploying to (<%= value %>)"}
+   :pom-file-missing                            {:title   "Missing POM file"
+                                                 :details "No POM file was uploaded"}
+   :pom-file-missing-license                    {:title   "Invalid POM file"
+                                                 :details "the POM file does not include a license. See https://bit.ly/3PQunZU"}
+   :pom-file-range-dependency                   {:title   "Invalid POM file"
+                                                 :details "the POM file includes a dependency with a version range. See https://bit.ly/44Z4Ggp"}
+   :pom-file-snapshot-dependency                {:title   "Invalid POM file"
+                                                 :details "the POM file includes a dependency with a SNAPSHOT version. See https://bit.ly/44Z4Ggp"}
+   :project-name-invalid                        {:title   "Invalid project name"
+                                                 :details "project names must consist solely of lowercase letters, numbers, hyphens and underscores. See https://bit.ly/3MuL20A"}
+   :redeploy-non-snapshot                       {:title   "Non-SNAPSHOT redeploy"
+                                                 :details "redeploying non-snapshots is not allowed. See https://bit.ly/3EYzhwT"}
+   :token-single-use-used                       {:title   "Deploy token used"
+                                                 :details "The provided single-use token has already been used"}
+   :token-scope-mismatch                        {:title   "Deploy token scope mismatch"
+                                                 :details "The provided token's scope doesn't allow deploying this artifact. See https://bit.ly/3LmCclv"}
+   :unknown-upload-error                        {:title   "Unknown error"
+                                                 :details "Unknown error. Message: <%= message %>"}
+   :version-invalid                             {:title   "Invalid version"
+                                                 :details "version strings must consist solely of letters, numbers, dots, pluses, hyphens and underscores. See https://bit.ly/3Kf5KzX"}})
 
 (defn- failure-tag->title
   [tag meta]
@@ -343,10 +349,22 @@
        {:module-value actual
         :value        expected}))))
 
+(defn- validate-module-dpendendencies
+  [module version]
+  (let [dep-versions (gradle/dependency-versions module)]
+    (when (some gradle/latest-metaversion-version? dep-versions)
+      (throw-invalid :gradle-module-latest-metaversion-dependency))
+    (when (some gradle/range-version? dep-versions)
+      (throw-invalid :gradle-module-range-dependency))
+    (when (and (not (maven/snapshot-version? version))
+               (some maven/snapshot-version? dep-versions))
+      (throw-invalid :gradle-module-snapshot-dependency))))
+
 (defn- validate-module [module group name version]
   (validate-module-entry module [:component :group] group)
   (validate-module-entry module [:component :module] name)
-  (validate-module-entry module [:component :version] version))
+  (validate-module-entry module [:component :version] version)
+  (validate-module-dpendendencies module version))
 
 (defn assert-non-redeploy [db group-id artifact-id version]
   (when (and (not (maven/snapshot-version? version))

--- a/src/clojars/routes/repo.clj
+++ b/src/clojars/routes/repo.clj
@@ -127,60 +127,66 @@
 
 (def ^:private failure-details
   ;; These use comb for templating, and can access any key in the metadata passed to throw-invalid
-  {:central-shadow                 {:title   "Cannot shadow Maven Central"
-                                    :details "shadowing Maven Central artifacts is not allowed. See https://bit.ly/3rTLqxZ"}
-   :central-shadow-check-failure   {:title   "Maven Central shadow check failed"
-                                    :details "failed to contact Maven Central to verify project name. See https://bit.ly/3rTLqxZ"}
-   :gradle-module-invalid          {:title   "Invalid Gradle module"
-                                    :details "failed to parse Gradle module. Message: <%= message %>"}
-   :gradle-module-mismatch-group   {:title   "Invalid Gradle module"
-                                    :details "the component group in the gradle module (<%= module-value %>) does not match the group you are deploying to (<%= value %>)"}
-   :gradle-module-mismatch-module  {:title   "Invalid Gradle module"
-                                    :details "the component module in the gradle module (<%= module-value %>) does not match the module you are deploying to (<%= value %>)"}
-   :gradle-module-mismatch-version {:title   "Invalid Gradle module"
-                                    :details "the component version in the gradle module (<%= module-value %>) does not match the version you are deploying to (<%= value %>)"}
-   :group-no-access                {:title   "Deploy group not accessible"
-                                    :details "You don't have access to the '<%= group %>/<%= project %>' project"}
-   :group-non-existent             {:title   "Deploy group does not exist"
-                                    :details "Group '<%= group %>' doesn't exist. See https://bit.ly/3MuKGXO"}
-   :group-non-verified             {:title   "Deploy group isn't verified"
-                                    :details "Group '<%= group %>' isn't verified, so can't contain new projects. See https://bit.ly/3MuKGXO"}
-   :group-requires-mfa             {:title   "Deploy group requires MFA"
-                                    :details "The group '<%= group %>' requires you to have two-factor auth enabled to deploy. See https://bit.ly/45qrtA8"}
-   :file-invalid-checksum          {:title   "Invalid checksum"
-                                    :details "invalid <%= checksum-type %> checksum for <%= filename %>"}
-   :file-missing-checksum          {:title   "File missing checksum"
-                                    :details "no checksums provided for <%= filename %>"}
-   :file-missing-signature         {:title   "File missing signature"
-                                    :details "file <%= filename %> has no <%= signature-type %> signature"}
-   :maven-metadata-file-invalid    {:title   "Invalid maven-metadata.xml file"
-                                    :details "failed to parse maven-metadata.xml file. Message: <%= message %>"}
-   :password-not-token             {:title   "No deploy token provided"
-                                    :details "a deploy token is required to deploy. See https://bit.ly/3LmCclv"}
-   :pom-file-invalid               {:title   "Invalid POM file"
-                                    :details "failed to parse POM file. Message: <%= message %>"}
-   :pom-file-mismatch-group        {:title   "Invalid POM file"
-                                    :details "the group in the pom (<%= pom-value %>) does not match the group you are deploying to (<%= value %>)"}
-   :pom-file-mismatch-name         {:title   "Invalid POM file"
-                                    :details "the name in the pom (<%= pom-value %>) does not match the name you are deploying to (<%= value %>)"}
-   :pom-file-mismatch-version      {:title   "Invalid POM file"
-                                    :details "the version in the pom (<%= pom-value %>) does not match the version you are deploying to (<%= value %>)"}
-   :pom-file-missing               {:title   "Missing POM file"
-                                    :details "No POM file was uploaded"}
-   :pom-file-missing-license       {:title   "Invalid POM file"
-                                    :details "the POM file does not include a license. See https://bit.ly/3PQunZU"}
-   :project-name-invalid           {:title   "Invalid project name"
-                                    :details "project names must consist solely of lowercase letters, numbers, hyphens and underscores. See https://bit.ly/3MuL20A"}
-   :redeploy-non-snapshot          {:title   "Non-SNAPSHOT redeploy"
-                                    :details "redeploying non-snapshots is not allowed. See https://bit.ly/3EYzhwT"}
-   :token-single-use-used          {:title   "Deploy token used"
-                                    :details "The provided single-use token has already been used"}
-   :token-scope-mismatch           {:title   "Deploy token scope mismatch"
-                                    :details "The provided token's scope doesn't allow deploying this artifact. See https://bit.ly/3LmCclv"}
-   :unknown-upload-error           {:title   "Unknown error"
-                                    :details "Unknown error. Message: <%= message %>"}
-   :version-invalid                {:title   "Invalid version"
-                                    :details "version strings must consist solely of letters, numbers, dots, pluses, hyphens and underscores. See https://bit.ly/3Kf5KzX"}})
+  {:central-shadow                         {:title   "Cannot shadow Maven Central"
+                                            :details "shadowing Maven Central artifacts is not allowed. See https://bit.ly/3rTLqxZ"}
+   :central-shadow-check-failure           {:title   "Maven Central shadow check failed"
+                                            :details "failed to contact Maven Central to verify project name. See https://bit.ly/3rTLqxZ"}
+   :gradle-module-invalid                  {:title   "Invalid Gradle module"
+                                            :details "failed to parse Gradle module. Message: <%= message %>"}
+   :gradle-module-mismatch-group           {:title   "Invalid Gradle module"
+                                            :details "the component group in the gradle module (<%= module-value %>) does not match the group you are deploying to (<%= value %>)"}
+   :gradle-module-mismatch-module          {:title   "Invalid Gradle module"
+                                            :details "the component module in the gradle module (<%= module-value %>) does not match the module you are deploying to (<%= value %>)"}
+   :gradle-module-mismatch-version         {:title   "Invalid Gradle module"
+                                            :details "the component version in the gradle module (<%= module-value %>) does not match the version you are deploying to (<%= value %>)"}
+   :group-no-access                        {:title   "Deploy group not accessible"
+                                            :details "You don't have access to the '<%= group %>/<%= project %>' project"}
+   :group-non-existent                     {:title   "Deploy group does not exist"
+                                            :details "Group '<%= group %>' doesn't exist. See https://bit.ly/3MuKGXO"}
+   :group-non-verified                     {:title   "Deploy group isn't verified"
+                                            :details "Group '<%= group %>' isn't verified, so can't contain new projects. See https://bit.ly/3MuKGXO"}
+   :group-requires-mfa                     {:title   "Deploy group requires MFA"
+                                            :details "The group '<%= group %>' requires you to have two-factor auth enabled to deploy. See https://bit.ly/45qrtA8"}
+   :file-invalid-checksum                  {:title   "Invalid checksum"
+                                            :details "invalid <%= checksum-type %> checksum for <%= filename %>"}
+   :file-missing-checksum                  {:title   "File missing checksum"
+                                            :details "no checksums provided for <%= filename %>"}
+   :file-missing-signature                 {:title   "File missing signature"
+                                            :details "file <%= filename %> has no <%= signature-type %> signature"}
+   :maven-metadata-file-invalid            {:title   "Invalid maven-metadata.xml file"
+                                            :details "failed to parse maven-metadata.xml file. Message: <%= message %>"}
+   :password-not-token                     {:title   "No deploy token provided"
+                                            :details "a deploy token is required to deploy. See https://bit.ly/3LmCclv"}
+   :pom-file-latest-metaversion-dependency {:title   "Invalid POM file"
+                                            :details "the POM file includes a dependency with a version of 'LATEST' or 'RELEASE'. See https://bit.ly/44Z4Ggp"}
+   :pom-file-invalid                       {:title   "Invalid POM file"
+                                            :details "failed to parse POM file. Message: <%= message %>"}
+   :pom-file-mismatch-group                {:title   "Invalid POM file"
+                                            :details "the group in the pom (<%= pom-value %>) does not match the group you are deploying to (<%= value %>)"}
+   :pom-file-mismatch-name                 {:title   "Invalid POM file"
+                                            :details "the name in the pom (<%= pom-value %>) does not match the name you are deploying to (<%= value %>)"}
+   :pom-file-mismatch-version              {:title   "Invalid POM file"
+                                            :details "the version in the pom (<%= pom-value %>) does not match the version you are deploying to (<%= value %>)"}
+   :pom-file-missing                       {:title   "Missing POM file"
+                                            :details "No POM file was uploaded"}
+   :pom-file-missing-license               {:title   "Invalid POM file"
+                                            :details "the POM file does not include a license. See https://bit.ly/3PQunZU"}
+   :pom-file-range-dependency              {:title   "Invalid POM file"
+                                            :details "the POM file includes a dependency with a version range. See https://bit.ly/44Z4Ggp"}
+   :pom-file-snapshot-dependency           {:title   "Invalid POM file"
+                                            :details "the POM file includes a dependency with a SNAPSHOT version. See https://bit.ly/44Z4Ggp"}
+   :project-name-invalid                   {:title   "Invalid project name"
+                                            :details "project names must consist solely of lowercase letters, numbers, hyphens and underscores. See https://bit.ly/3MuL20A"}
+   :redeploy-non-snapshot                  {:title   "Non-SNAPSHOT redeploy"
+                                            :details "redeploying non-snapshots is not allowed. See https://bit.ly/3EYzhwT"}
+   :token-single-use-used                  {:title   "Deploy token used"
+                                            :details "The provided single-use token has already been used"}
+   :token-scope-mismatch                   {:title   "Deploy token scope mismatch"
+                                            :details "The provided token's scope doesn't allow deploying this artifact. See https://bit.ly/3LmCclv"}
+   :unknown-upload-error                   {:title   "Unknown error"
+                                            :details "Unknown error. Message: <%= message %>"}
+   :version-invalid                        {:title   "Invalid version"
+                                            :details "version strings must consist solely of letters, numbers, dots, pluses, hyphens and underscores. See https://bit.ly/3Kf5KzX"}})
 
 (defn- failure-tag->title
   [tag meta]
@@ -310,11 +316,22 @@
   (when (empty? (:licenses pom))
     (throw-invalid :pom-file-missing-license)))
 
+(defn- validate-pom-dpendendencies
+  [{:as _pom :keys [dependencies]} version]
+  (when (some #(maven/latest-metaversion-version? (:version %)) dependencies)
+    (throw-invalid :pom-file-latest-metaversion-dependency))
+  (when (some #(maven/range-version? (:version %)) dependencies)
+    (throw-invalid :pom-file-range-dependency))
+  (when (and (not (maven/snapshot-version? version))
+             (some #(maven/snapshot-version? (:version %)) dependencies))
+    (throw-invalid :pom-file-snapshot-dependency)))
+
 (defn- validate-pom [pom group name version]
   (validate-pom-entry pom :group group)
   (validate-pom-entry pom :name name)
   (validate-pom-entry pom :version version)
-  (validate-pom-license pom))
+  (validate-pom-license pom)
+  (validate-pom-dpendendencies pom version))
 
 (defn- validate-module-entry
   "Validates a key in a Gradle module"

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -923,6 +923,88 @@
                      :message "a deploy token is required to deploy. See https://bit.ly/3LmCclv"
                      :tag     "deploy-password-rejection"}))
 
+(deftest deploy-requires-non-latest-metaversion-dependency-versions
+  (doseq [version ["LATEST" "RELEASE"]]
+    (-> (session (help/app))
+        (register-as "dantheman" "test@example.org" "password1234"))
+    (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+      (testing (format "with a version of %s" version)
+        (is (thrown-with-msg? DeploymentException
+                              #"status=403,.*detail='the POM file includes a dependency with a version of 'LATEST' or 'RELEASE'"
+              (deploy
+               {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+                :jar-file (io/file (io/resource "test.jar"))
+                :pom-file (help/update-pom-dependency (io/file (io/resource "test-0.0.1/test.pom"))
+                                                      0 {:version version})
+                :password  token})))
+
+        (help/match-audit {:username "dantheman"}
+                          {:user "dantheman"
+                           :group_name "org.clojars.dantheman"
+                           :jar_name "test"
+                           :message "the POM file includes a dependency with a version of 'LATEST' or 'RELEASE'. See https://bit.ly/44Z4Ggp"
+                           :tag "pom-file-latest-metaversion-dependency"})))))
+
+(deftest deploy-requires-non-range-dependency-versions
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password1234"))
+  (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    (is (thrown-with-msg? DeploymentException
+                          #"status=403,.*detail='the POM file includes a dependency with a version range"
+          (deploy
+           {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+            :jar-file (io/file (io/resource "test.jar"))
+            :pom-file (help/update-pom-dependency (io/file (io/resource "test-0.0.1/test.pom"))
+                                                  0 {:version "[0,1)"})
+            :password  token})))
+
+    (help/match-audit {:username "dantheman"}
+                      {:user "dantheman"
+                       :group_name "org.clojars.dantheman"
+                       :jar_name "test"
+                       :message "the POM file includes a dependency with a version range. See https://bit.ly/44Z4Ggp"
+                       :tag "pom-file-range-dependency"})))
+
+(deftest deploy-requires-non-SNAPSHOT-dependency-versions
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password1234"))
+  (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    (is (thrown-with-msg? DeploymentException
+                          #"status=403,.*detail='the POM file includes a dependency with a SNAPSHOT version"
+          (deploy
+           {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+            :jar-file (io/file (io/resource "test.jar"))
+            :pom-file (help/update-pom-dependency (io/file (io/resource "test-0.0.1/test.pom"))
+                                                  0 {:version "0.0.1-SNAPSHOT"})
+            :password  token})))
+
+    (help/match-audit {:username "dantheman"}
+                      {:user "dantheman"
+                       :group_name "org.clojars.dantheman"
+                       :jar_name "test"
+                       :message "the POM file includes a dependency with a SNAPSHOT version. See https://bit.ly/44Z4Ggp"
+                       :tag "pom-file-snapshot-dependency"})))
+
+(deftest deploy-allows-SNAPSHOT-dependency-versions-for-snapshots
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password1234"))
+  (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    (deploy
+     {:coordinates '[org.clojars.dantheman/test "1.0.0-SNAPSHOT"]
+      :jar-file (io/file (io/resource "test.jar"))
+
+      :pom-file (-> (io/file (io/resource "test-0.0.1/test.pom"))
+                    (help/rewrite-pom {:version "1.0.0-SNAPSHOT"})
+                    (help/update-pom-dependency 0 {:version "0.0.1-SNAPSHOT"}))
+      :password  token})
+
+    (help/match-audit {:username "dantheman"}
+                      {:tag "deployed"
+                       :user "dantheman"
+                       :group_name "org.clojars.dantheman"
+                       :jar_name "test"
+                       :version "1.0.0-SNAPSHOT"})))
+
 (deftest deploy-requires-path-to-match-pom
   (-> (session (help/app))
       (register-as "dantheman" "test@example.org" "password1234"))
@@ -1035,6 +1117,31 @@
                        :version "1.0.0"
                        :message "the component version in the gradle module (0.0.1) does not match the version you are deploying to (1.0.0)"
                        :tag "gradle-module-mismatch-version"})))
+
+(deftest deploy-requires-non-latest-metaversion-dependency-versions-in-module
+  (doseq [version ["latest.integration" "latest.release"]]
+    (testing (format "with a version of %s" version)
+      (-> (session (help/app))
+          (register-as "dantheman" "test@example.org" "password1234"))
+      (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+        (is (thrown-with-msg?
+             DeploymentException
+             #"status=403,.*detail='the Gradle module includes a dependency with a version of 'latest\.integration' or 'latest\.release'"
+              (deploy
+               {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+                :jar-file (io/file (io/resource "test.jar"))
+                :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
+                :module-file (-> (io/file (io/resource "test-0.0.1/test.module"))
+                                 (help/update-module-dependency 0 {:version {:requires version}}))
+                :password  token})))
+
+        (help/match-audit {:username "dantheman"}
+                          {:user "dantheman"
+                           :group_name "org.clojars.dantheman"
+                           :jar_name "test"
+                           :version "0.0.1"
+                           :message "the Gradle module includes a dependency with a version of 'latest.integration' or 'latest.release'. See https://bit.ly/44Z4Ggp"
+                           :tag "gradle-module-latest-metaversion-dependency"})))))
 
 (deftest deploy-requires-lowercase-project
   (-> (session (help/app))

--- a/test/clojars/integration/uploads_test.clj
+++ b/test/clojars/integration/uploads_test.clj
@@ -1119,8 +1119,9 @@
                        :tag "gradle-module-mismatch-version"})))
 
 (deftest deploy-requires-non-latest-metaversion-dependency-versions-in-module
-  (doseq [version ["latest.integration" "latest.release"]]
-    (testing (format "with a version of %s" version)
+  (doseq [version ["latest.integration" "latest.release"]
+          version-type [:prefers :requires :strictly]]
+    (testing (format "with a version %s and type %s" version version-type)
       (-> (session (help/app))
           (register-as "dantheman" "test@example.org" "password1234"))
       (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
@@ -1132,7 +1133,7 @@
                 :jar-file (io/file (io/resource "test.jar"))
                 :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
                 :module-file (-> (io/file (io/resource "test-0.0.1/test.module"))
-                                 (help/update-module-dependency 0 {:version {:requires version}}))
+                                 (help/update-module-dependency 0 {:version {version-type version}}))
                 :password  token})))
 
         (help/match-audit {:username "dantheman"}
@@ -1142,6 +1143,80 @@
                            :version "0.0.1"
                            :message "the Gradle module includes a dependency with a version of 'latest.integration' or 'latest.release'. See https://bit.ly/44Z4Ggp"
                            :tag "gradle-module-latest-metaversion-dependency"})))))
+
+(deftest deploy-requires-non-range-dependency-versions-in-module
+  (doseq [version ["[1,2)" "1.+" "+"]
+          version-type [:prefers :requires :strictly]]
+    (testing (format "with a range version %s and type %s" version version-type)
+      (-> (session (help/app))
+          (register-as "dantheman" "test@example.org" "password1234"))
+      (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+        (is (thrown-with-msg?
+             DeploymentException
+             #"status=403,.*detail='the Gradle module includes a dependency with a version range"
+              (deploy
+               {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+                :jar-file (io/file (io/resource "test.jar"))
+                :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
+                :module-file (-> (io/file (io/resource "test-0.0.1/test.module"))
+                                 (help/update-module-dependency 0 {:version {version-type version}}))
+                :password  token})))
+
+        (help/match-audit {:username "dantheman"}
+                          {:user "dantheman"
+                           :group_name "org.clojars.dantheman"
+                           :jar_name "test"
+                           :version "0.0.1"
+                           :message "the Gradle module includes a dependency with a version range. See https://bit.ly/44Z4Ggp"
+                           :tag "gradle-module-range-dependency"})))))
+
+;; NOCOMMIT: (toby)
+;; - test strictly, prefers
+(deftest deploy-requires-non-SNAPSHOT-dependency-versions-in-module
+  (doseq [version-type [:prefers :requires :strictly]]
+    (testing (format "with a SNAPSHOT version with type %s" version-type)
+      (-> (session (help/app))
+          (register-as "dantheman" "test@example.org" "password1234"))
+      (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+        (is (thrown-with-msg?
+             DeploymentException
+             #"status=403,.*detail='the Gradle module includes a dependency with a SNAPSHOT version"
+              (deploy
+               {:coordinates '[org.clojars.dantheman/test "0.0.1"]
+                :jar-file (io/file (io/resource "test.jar"))
+                :pom-file (io/file (io/resource "test-0.0.1/test.pom"))
+                :module-file (-> (io/file (io/resource "test-0.0.1/test.module"))
+                                 (help/update-module-dependency 0 {:version {version-type "1-SNAPSHOT"}}))
+                :password  token})))
+
+        (help/match-audit {:username "dantheman"}
+                          {:user "dantheman"
+                           :group_name "org.clojars.dantheman"
+                           :jar_name "test"
+                           :version "0.0.1"
+                           :message "the Gradle module includes a dependency with a SNAPSHOT version. See https://bit.ly/44Z4Ggp"
+                           :tag "gradle-module-snapshot-dependency"})))))
+
+(deftest deploy-allows-SNAPSHOT-dependency-versions-in-SNAPSHOT-module
+  (-> (session (help/app))
+      (register-as "dantheman" "test@example.org" "password1234"))
+  (let [token (create-deploy-token (session (help/app)) "dantheman" "password1234" "testing")]
+    (deploy
+     {:coordinates '[org.clojars.dantheman/test "0.0.1-SNAPSHOT"]
+      :jar-file (io/file (io/resource "test.jar"))
+      :pom-file (-> (io/file (io/resource "test-0.0.1/test.pom"))
+                    (help/rewrite-pom {:version "0.0.1-SNAPSHOT"}))
+      :module-file (-> (io/file (io/resource "test-0.0.1/test.module"))
+                       (help/update-module-component {:version "0.0.1-SNAPSHOT"})
+                       (help/update-module-dependency 0 {:version {:requires "1-SNAPSHOT"}}))
+      :password token})
+
+    (help/match-audit {:username "dantheman"}
+                      {:tag "deployed"
+                       :user "dantheman"
+                       :group_name "org.clojars.dantheman"
+                       :jar_name "test"
+                       :version "0.0.1-SNAPSHOT"})))
 
 (deftest deploy-requires-lowercase-project
   (-> (session (help/app))

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -1,6 +1,7 @@
 (ns clojars.test-helper
   (:require
    [cemerick.pomegranate.aether :as aether]
+   [cheshire.core :as json]
    [clojars.config :as config]
    [clojars.db :as db]
    [clojars.db.migrate :as migrate]
@@ -183,6 +184,28 @@
         dep (nth (.getDependencies model) idx)]
     (java.data/set-properties dep m)
     (write-pom model file)))
+
+(defn- write-module
+  [module ^File file]
+  (let [new-module-file (doto (File/createTempFile (.getName file) ".module")
+                          .deleteOnExit)]
+    (spit new-module-file (json/encode module))
+    new-module-file))
+
+(defn update-module-dependency
+  [file idx m]
+  (-> (slurp file)
+      (json/decode true)
+      (update-in [:variants 0 :dependencies idx]
+                 merge m)
+      (write-module file)))
+
+(defn update-module-component
+  [^File file m]
+  (-> (slurp file)
+      (json/decode true)
+      (update :component merge m)
+      (write-module file)))
 
 (defn add-verified-group
   [account group]

--- a/test/clojars/test_helper.clj
+++ b/test/clojars/test_helper.clj
@@ -8,12 +8,14 @@
    [clojars.email :as email]
    [clojars.errors :as errors]
    [clojars.http-kit :as http-kit]
+   [clojars.maven :as maven]
    [clojars.oauth.service :as oauth-service]
    [clojars.s3 :as s3]
    [clojars.search :as search]
    [clojars.stats :as stats]
    [clojars.system :as system]
    [clojars.web :as web]
+   [clojure.java.data :as java.data]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]
@@ -32,8 +34,12 @@
     FileUtils)
    (org.apache.lucene.store
     ByteBuffersDirectory)
+   (org.apache.maven.model
+    Model)
    (org.apache.maven.wagon.providers.http
     HttpWagon)))
+
+(set! *warn-on-reflection* true)
 
 (def tmp-dir (io/file (System/getProperty "java.io.tmpdir")))
 (def local-repo (io/file tmp-dir "clojars" "test" "local-repo"))
@@ -158,16 +164,25 @@
   [resp]
   (= "*" (get-in resp [:headers :access-control-allow-origin])))
 
-(defn rewrite-pom [file m]
+(defn- write-pom
+  [^Model model ^File file]
   (let [new-pom (doto (File/createTempFile (.getName file) ".pom")
                   .deleteOnExit)]
-    (spit new-pom
-          (reduce (fn [accum [element new-value]]
-                    (str/replace accum (re-pattern (format "<(%s)>.*?<" (name element)))
-                                 (format "<$1>%s<" new-value)))
-                  (slurp file)
-                  m))
+    (maven/write-pom model new-pom)
     new-pom))
+
+(defn rewrite-pom
+  [file m]
+  (let [model (maven/read-pom file)]
+    (java.data/set-properties model m)
+    (write-pom model file)))
+
+(defn update-pom-dependency
+  [file idx m]
+  (let [model (maven/read-pom file)
+        dep (nth (.getDependencies model) idx)]
+    (java.data/set-properties dep m)
+    (write-pom model file)))
 
 (defn add-verified-group
   [account group]


### PR DESCRIPTION
### Don't allow dynamic versions in pom deps

This prevents build instability by making the transitive dependency tree
stable.

Implements #955.

### Don't allow dynamic versions in gradle module deps

This prevents build instability by making the transitive dependency tree
stable.

Implements #955.

---

This change links to a wiki page that is currently a draft: https://github.com/clojars/clojars-web/wiki/Unstable-Dependency-Versions