### PR TITLE
Update to latest clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,9 +20,6 @@
   ;; use the resolved value
   :case-symbol-test {:level :warning}
 
-  ;; warn when we'll never reach an else
-  :condition-always-true {:level :warning}
-
   ;; warn when let bindings can be replaced by cond->
   :conditional-build-up {:level :warning}
   

--- a/bin/clj-kondo
+++ b/bin/clj-kondo
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-CLJ_KONDO_VERSION="2026.05.25"
+CLJ_KONDO_VERSION="2026.07.24"
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
 
 function ensure_clj_kondo() {

--- a/test/clojars/unit/verification_test.clj
+++ b/test/clojars/unit/verification_test.clj
@@ -127,7 +127,7 @@
            (nut/verify-group-by-TXT help/*db* {:username "dantheman"
                                                :group   "com.foo"
                                                :domain  "foo.com"}))))
-    (is (db/group-activenames help/*db* "com.foo"))
+    (is (seq (db/group-activenames help/*db* "com.foo")))
     (is (db/find-group-verification help/*db* "com.foo"))))
 
 (deftest verify-group-by-parent-group-with-invalid-group


### PR DESCRIPTION
This adds a new linter that is on by default: :constant-condition. It
replaces :condition-always-true, so we can remove that from the config.
This also addresses the issue the new linter found.